### PR TITLE
Flash mint to an arbitrary address

### DIFF
--- a/contracts/WETH10.sol
+++ b/contracts/WETH10.sol
@@ -91,14 +91,14 @@ contract WETH10 {
     /// The flash minted WETH10 is not backed by real Ether, but can be withdrawn as such up to the Ether balance of this contract.
     /// Arbitrary data can be passed as a bytes calldata parameter.
     /// Emits two {Transfer} events for minting and burning of the flash minted amount.
-    function flashMint(uint256 value, bytes calldata data) external {
+    function flashMint(address to, uint256 value, bytes calldata data) external {
         supplyTargets.push(address(this).balance + flashSupply);
         flashSupply += value;
         require(address(this).balance + flashSupply <= type(uint112).max, "WETH::flashMint: supply limit exceeded");
-        balanceOf[msg.sender] += value;
-        emit Transfer(address(0), msg.sender, value);
+        balanceOf[to] += value;
+        emit Transfer(address(0), to, value);
 
-        FlashMinterLike(msg.sender).executeOnFlashMint(data);
+        FlashMinterLike(to).executeOnFlashMint(data);
 
         require(address(this).balance + flashSupply == supplyTargets[supplyTargets.length - 1], "WETH::flashMint: supply not restored");
         supplyTargets.pop();

--- a/contracts/tests/TestFlashMinter.sol
+++ b/contracts/tests/TestFlashMinter.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.7.0;
 
 interface FlashMintableLike {
-    function flashMint(uint256, bytes calldata) external;
+    function flashMint(address, uint256, bytes calldata) external;
     function flashBurn(uint256) external;
     function balanceOf(address) external returns (uint256);
     function deposit() external payable;
@@ -42,29 +42,29 @@ contract TestFlashMinter {
     function flashMint(address target, uint256 value) public {
         // Use this to pack arbitrary data to `executeOnFlashMint`
         bytes memory data = abi.encode(Action.NORMAL, msg.sender, value); // Here msg.sender is the user, and target is the weth contract
-        FlashMintableLike(target).flashMint(value, data);
+        FlashMintableLike(target).flashMint(address(this), value, data);
     }
 
     function flashMintAndWithdraw(address target, uint256 value) public {
         // Use this to pack arbitrary data to `executeOnFlashMint`
         bytes memory data = abi.encode(Action.WITHDRAW, msg.sender, value); // Here msg.sender is the user, and target is the weth contract
-        FlashMintableLike(target).flashMint(value, data);
+        FlashMintableLike(target).flashMint(address(this), value, data);
     }
 
     function flashMintAndSteal(address target, uint256 value) public {
         // Use this to pack arbitrary data to `executeOnFlashMint`
         bytes memory data = abi.encode(Action.STEAL, msg.sender, value); // Here msg.sender is the user, and target is the weth contract
-        FlashMintableLike(target).flashMint(value, data);
+        FlashMintableLike(target).flashMint(address(this), value, data);
     }
 
     function flashMintAndReenter(address target, uint256 value) public {
         // Use this to pack arbitrary data to `executeOnFlashMint`
         bytes memory data = abi.encode(Action.REENTER, msg.sender, value); // Here msg.sender is the user, and target is the weth contract
-        FlashMintableLike(target).flashMint(value, data);
+        FlashMintableLike(target).flashMint(address(this), value, data);
     }
 
     function flashMintAndOverspend(address target, uint256 value) public {
         bytes memory data = abi.encode(Action.OVERSPEND, msg.sender, value); // Here msg.sender is the user, and target is the weth contract
-        FlashMintableLike(target).flashMint(value, data);
+        FlashMintableLike(target).flashMint(msg.sender, value, data);
     }
 }

--- a/test/02_WETH10_Flash.test.js
+++ b/test/02_WETH10_Flash.test.js
@@ -37,14 +37,7 @@ contract('WETH10 - Flash Minting', (accounts) => {
   it('should not steal a flash mint', async () => {
     await expectRevert(
       flash.flashMintAndSteal(weth.address, 1, { from: deployer }),
-      'WETH::flashMint: transfer amount exceeds balance'
-    )
-  })
-
-  it('needs to return funds after a flash mint', async () => {
-    await expectRevert(
-      flash.flashMintAndOverspend(weth.address, 1, { from: user1 }),
-      'WETH::flashMint: transfer amount exceeds balance'
+      'WETH::flashMint: supply not restored'
     )
   })
 


### PR DESCRIPTION
 - `flashMint` gains a `to` address where the WETH it minted, and where the callback is executed.
 - Instead of burning the WETH, there is a `flashBurn` method that must be called by someone.
 - Nested flash mints are recorded in an array so that the supply levels can be unwound.