### PR TITLE
feat: convert to weth9

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,6 @@ This function will call `onTokenTransfer` on the recipient address, receiving an
 This contract allows to `flashMint` an arbitrary amount of Wrapped Ether, unbacked by real Ether, with the condition that it is burned before the end of the transaction. 
 
 This function will call `executeOnFlashMint` on the calling address, receiving and passing along a `bytes` parameter which can be used by the calling contract to process the callback.
+
+## Convert to WETH9
+This contract allows to convert WETH10 into WETH9 at a minimal cost, using `convert` functions. Combining `convertFrom` with `permit` this conversion can be done at no cost to the WETH10 holder.

--- a/contracts/IWETH10.sol
+++ b/contracts/IWETH10.sol
@@ -58,6 +58,29 @@ interface IWETH10 is IERC20, IERC2612 {
     ///   - `from` account must have approved caller to spend at least `value` of WETH10 token, unless `from` and caller are the same account.
     function withdrawFrom(address from, address to, uint256 value) external;
 
+
+    /// @dev Exchange `value` WETH10 token from caller account for WETH9 token.
+    /// Emits {Transfer} event to reflect WETH10 token burn of `value` WETH10 token to zero address from caller account. 
+    /// Requirements:
+    ///   - caller account must have at least `value` balance of WETH10 token.
+    function convert(uint256 value) external;
+
+    /// @dev Exchange `value` WETH10 token from caller account for WETH9 token credited to account (`to`).
+    /// Emits {Transfer} event to reflect WETH10 token burn of `value` WETH10 token to zero address from caller account.
+    /// Requirements:
+    ///   - caller account must have at least `value` balance of WETH10 token.
+    function convertTo(address to, uint256 value) external;
+
+    /// @dev Exchange `value` WETH10 token from account (`from`) for WETH9 token credited to account (`to`).
+    /// Emits {Approval} event to reflect reduced allowance `value` for caller account to spend from account (`from`),
+    /// unless allowance is set to `type(uint256).max`
+    /// Emits {Transfer} event to reflect WETH10 token burn of `value` to zero address from account (`from`).
+    /// Requirements:
+    ///   - `from` account must have at least `value` balance of WETH10 token.
+    ///   - `from` account must have approved caller to spend at least `value` of WETH10 token, unless `from` and caller are the same account.
+    function convertFrom(address from, address to, uint256 value) external;
+
+
     /// @dev Moves `value` WETH10 token from caller's account to account (`to`), after which a call is executed to an ERC677-compliant contract.
     /// Returns boolean value indicating whether operation succeeded.
     /// Emits {Transfer} event.

--- a/contracts/WETH10.sol
+++ b/contracts/WETH10.sol
@@ -14,6 +14,11 @@ interface FlashMinterLike {
     function executeOnFlashMint(bytes calldata) external;
 }
 
+interface WETH9Like {
+    function deposit() external payable;
+    function transfer(address, uint) external returns (bool);
+}
+
 /// @dev WETH10 is an Ether ERC20 wrapper. You can `deposit` Ether and obtain Wrapped Ether which can then be operated as an ERC20 token. You can
 /// `withdraw` Ether from WETH10, which will burn Wrapped Ether in your wallet. The amount of Wrapped Ether in any wallet is always identical to the
 /// balance of Ether deposited minus the Ether withdrawn with that specific wallet.
@@ -24,6 +29,9 @@ contract WETH10 is IWETH10 {
     uint8  public constant decimals = 18;
 
     bytes32 public immutable PERMIT_TYPEHASH = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+
+    /// @dev WETH9 contract
+    WETH9Like public weth9;
 
     /// @dev Records amount of WETH10 token owned by account.
     mapping (address => uint256) public override balanceOf;
@@ -37,6 +45,11 @@ contract WETH10 is IWETH10 {
 
     /// @dev Current amount of flash minted WETH.
     uint256 public override flashSupply;
+
+    /// @dev The constructor takes the address of the WETH9 contract to allow conversions
+    constructor (address weth9_) {
+        weth9 = WETH9Like(weth9_);
+    }
 
     /// @dev Fallback, `msg.value` of ether sent to contract grants caller account a matching increase in WETH10 token balance.
     /// Emits {Transfer} event to reflect WETH10 token mint of `msg.value` from zero address to caller account.
@@ -155,9 +168,65 @@ contract WETH10 is IWETH10 {
         balanceOf[from] -= value;
 
         (bool success, ) = to.call{value: value}("");
-        require(success, "WETH::withdraw: Ether transfer failed");
+        require(success, "WETH::withdrawFrom: Ether transfer failed");
 
         emit Transfer(from, address(0), value);
+    }
+
+    /// @dev Exchange `value` WETH10 token from caller account for WETH9 token.
+    /// Emits {Transfer} event to reflect WETH10 token burn of `value` WETH10 token to zero address from caller account. 
+    /// Requirements:
+    ///   - caller account must have at least `value` balance of WETH10 token.
+    function convert(uint256 value) external override {
+        require(balanceOf[msg.sender] >= value, "WETH::convert: convert amount exceeds balance");
+        balanceOf[msg.sender] -= value;
+
+        emit Transfer(msg.sender, address(0), value);
+
+        weth9.deposit{value: value}();
+        require(weth9.transfer(msg.sender, value), "WETH::convert: WETH transfer failed");
+    }
+
+    /// @dev Exchange `value` WETH10 token from caller account for WETH9 token credited to account (`to`).
+    /// Emits {Transfer} event to reflect WETH10 token burn of `value` WETH10 token to zero address from caller account.
+    /// Requirements:
+    ///   - caller account must have at least `value` balance of WETH10 token.
+    function convertTo(address to, uint256 value) external override {
+        require(balanceOf[msg.sender] >= value, "WETH::convertTo: convert amount exceeds balance");
+        require(to != address(this), "WETH::convertTo: invalid recipient");
+        balanceOf[msg.sender] -= value;
+
+        emit Transfer(msg.sender, address(0), value);
+    
+        weth9.deposit{value: value}();
+        require(weth9.transfer(to, value), "WETH::convert: WETH transfer failed");
+    }
+
+    /// @dev Exchange `value` WETH10 token from account (`from`) for WETH9 token credited to account (`to`).
+    /// Emits {Approval} event to reflect reduced allowance `value` for caller account to spend from account (`from`),
+    /// unless allowance is set to `type(uint256).max`
+    /// Emits {Transfer} event to reflect WETH10 token burn of `value` to zero address from account (`from`).
+    /// Requirements:
+    ///   - `from` account must have at least `value` balance of WETH10 token.
+    ///   - `from` account must have approved caller to spend at least `value` of WETH10 token, unless `from` and caller are the same account.
+    function convertFrom(address from, address to, uint256 value) external override {
+        require(balanceOf[from] >= value, "WETH::convertFrom: convert amount exceeds balance");
+        require(to != address(this), "WETH::convertFrom: invalid recipient");
+        
+        if (from != msg.sender) {
+            uint256 allowed = allowance[from][msg.sender];
+            if (allowed != type(uint256).max) {
+                require(allowed >= value, "WETH::convertFrom: convert amount exceeds allowance");
+                allowance[from][msg.sender] = allowed - value;
+                emit Approval(from, msg.sender, allowed - value);
+            }
+        }
+        balanceOf[from] -= value;
+
+        emit Transfer(from, address(0), value);
+
+        weth9.deposit{value: value}();
+        require(weth9.transfer(to, value), "WETH::convert: WETH transfer failed");
     }
 
     /// @dev Sets `value` as allowance of `spender` account over caller account's WETH10 token.

--- a/contracts/WETH10.sol
+++ b/contracts/WETH10.sol
@@ -31,7 +31,7 @@ contract WETH10 is IWETH10 {
     bytes32 public immutable PERMIT_TYPEHASH = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
 
     /// @dev WETH9 contract
-    WETH9Like public weth9;
+    WETH9Like public immutable weth9;
 
     /// @dev Records amount of WETH10 token owned by account.
     mapping (address => uint256) public override balanceOf;

--- a/contracts/fuzzing/WETH10Fuzzing.sol
+++ b/contracts/fuzzing/WETH10Fuzzing.sol
@@ -18,7 +18,7 @@ contract WETH10Fuzzing {
 
     /// @dev Instantiate the WETH10 contract, and a holder address that will return weth when asked to.
     constructor () {
-        weth = new WETH10();
+        weth = new WETH10(address(0));
         holder = address(new MockHolder(address(weth), address(this)));
     }
 

--- a/contracts/tests/WETH9.sol
+++ b/contracts/tests/WETH9.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2015, 2016, 2017 Dapphub
+
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+pragma solidity ^0.7.0;
+
+contract WETH9 {
+    string public name     = "Wrapped Ether";
+    string public symbol   = "WETH";
+    uint8  public decimals = 18;
+
+    event  Approval(address indexed src, address indexed guy, uint wad);
+    event  Transfer(address indexed src, address indexed dst, uint wad);
+    event  Deposit(address indexed dst, uint wad);
+    event  Withdrawal(address indexed src, uint wad);
+
+    mapping (address => uint)                       public  balanceOf;
+    mapping (address => mapping (address => uint))  public  allowance;
+
+    receive() external payable {
+        deposit();
+    }
+    function deposit() public payable {
+        balanceOf[msg.sender] += msg.value;
+        emit Deposit(msg.sender, msg.value);
+    }
+    function withdraw(uint wad) public {
+        require(balanceOf[msg.sender] >= wad);
+        balanceOf[msg.sender] -= wad;
+        msg.sender.transfer(wad);
+        emit Withdrawal(msg.sender, wad);
+    }
+
+    function totalSupply() public view returns (uint) {
+        return address(this).balance;
+    }
+
+    function approve(address guy, uint wad) public returns (bool) {
+        allowance[msg.sender][guy] = wad;
+        emit Approval(msg.sender, guy, wad);
+        return true;
+    }
+
+    function transfer(address dst, uint wad) public returns (bool) {
+        return transferFrom(msg.sender, dst, wad);
+    }
+
+    function transferFrom(address src, address dst, uint wad)
+        public
+        returns (bool)
+    {
+        require(balanceOf[src] >= wad);
+
+        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
+            require(allowance[src][msg.sender] >= wad);
+            allowance[src][msg.sender] -= wad;
+        }
+
+        balanceOf[src] -= wad;
+        balanceOf[dst] += wad;
+
+        emit Transfer(src, dst, wad);
+
+        return true;
+    }
+}

--- a/test/01_WETH10.test.js
+++ b/test/01_WETH10.test.js
@@ -1,3 +1,4 @@
+const WETH9 = artifacts.require('WETH9')
 const WETH10 = artifacts.require('WETH10')
 const { signERC2612Permit } = require('eth-permit')
 const TestERC677Receiver = artifacts.require('TestERC677Receiver')
@@ -10,55 +11,57 @@ const MAX = "1157920892373161954235709850086879078532699846656405640394575840079
 
 contract('WETH10', (accounts) => {
   const [deployer, user1, user2, user3] = accounts
-  let weth
+  let weth9
+  let weth10
 
   beforeEach(async () => {
-    weth = await WETH10.new({ from: deployer })
+    weth9 = await WETH9.new({ from: deployer })
+    weth10 = await WETH10.new(weth9.address, { from: deployer })
   })
 
   describe('deployment', async () => {
     it('returns the name', async () => {
-      let name = await weth.name()
+      let name = await weth10.name()
       name.should.equal('Wrapped Ether v10')
     })
 
     it('deposits ether', async () => {
-      const balanceBefore = await weth.balanceOf(user1)
-      await weth.deposit({ from: user1, value: 1 })
-      const balanceAfter = await weth.balanceOf(user1)
+      const balanceBefore = await weth10.balanceOf(user1)
+      await weth10.deposit({ from: user1, value: 1 })
+      const balanceAfter = await weth10.balanceOf(user1)
       balanceAfter.toString().should.equal(balanceBefore.add(new BN('1')).toString())
     })
 
     it('deposits ether using the legacy method', async () => {
-      const balanceBefore = await weth.balanceOf(user1)
-      await weth.sendTransaction({ from: user1, value: 1 })
-      const balanceAfter = await weth.balanceOf(user1)
+      const balanceBefore = await weth10.balanceOf(user1)
+      await weth10.sendTransaction({ from: user1, value: 1 })
+      const balanceAfter = await weth10.balanceOf(user1)
       balanceAfter.toString().should.equal(balanceBefore.add(new BN('1')).toString())
     })
 
     it('deposits ether to another account', async () => {
-      const balanceBefore = await weth.balanceOf(user2)
-      await weth.depositTo(user2, { from: user1, value: 1 })
-      const balanceAfter = await weth.balanceOf(user2)
+      const balanceBefore = await weth10.balanceOf(user2)
+      await weth10.depositTo(user2, { from: user1, value: 1 })
+      const balanceAfter = await weth10.balanceOf(user2)
       balanceAfter.toString().should.equal(balanceBefore.add(new BN('1')).toString())
     })
 
     it('should not depositTo to the contract address', async () => {
-      await expectRevert(weth.depositTo(weth.address, { value: 1, from: user1 }), 'WETH::depositTo: invalid recipient')
+      await expectRevert(weth10.depositTo(weth10.address, { value: 1, from: user1 }), 'WETH::depositTo: invalid recipient')
     })
 
     it('should not depositToAndCall to the contract address', async () => {
-      await expectRevert(weth.depositToAndCall(weth.address, '0x11', { from: user1, value: 1 }), 'WETH::depositToAndCall: invalid recipient')
+      await expectRevert(weth10.depositToAndCall(weth10.address, '0x11', { from: user1, value: 1 }), 'WETH::depositToAndCall: invalid recipient')
     })
 
     it('deposits with depositToAndCall', async () => {
       const receiver = await TestERC677Receiver.new()
-      await weth.depositToAndCall(receiver.address, '0x11', { from: user1, value: 1 })
+      await weth10.depositToAndCall(receiver.address, '0x11', { from: user1, value: 1 })
 
       const events = await receiver.getPastEvents()
       events.length.should.equal(1)
       events[0].event.should.equal('TransferReceived')
-      events[0].returnValues.token.should.equal(weth.address)
+      events[0].returnValues.token.should.equal(weth10.address)
       events[0].returnValues.sender.should.equal(user1)
       events[0].returnValues.value.should.equal('1')
       events[0].returnValues.data.should.equal('0x11')
@@ -66,28 +69,28 @@ contract('WETH10', (accounts) => {
 
     describe('with a positive balance', async () => {
       beforeEach(async () => {
-        await weth.deposit({ from: user1, value: 10 })
+        await weth10.deposit({ from: user1, value: 10 })
       })
 
       it('returns the Ether balance as total supply', async () => {
-        const totalSupply = await weth.totalSupply()
+        const totalSupply = await weth10.totalSupply()
         totalSupply.toString().should.equal('10')
       })
 
       it('withdraws ether', async () => {
-        const balanceBefore = await weth.balanceOf(user1)
-        await weth.withdraw(1, { from: user1 })
-        const balanceAfter = await weth.balanceOf(user1)
+        const balanceBefore = await weth10.balanceOf(user1)
+        await weth10.withdraw(1, { from: user1 })
+        const balanceAfter = await weth10.balanceOf(user1)
         balanceAfter.toString().should.equal(balanceBefore.sub(new BN('1')).toString())
       })
 
       it('withdraws ether to another account', async () => {
-        const fromBalanceBefore = await weth.balanceOf(user1)
+        const fromBalanceBefore = await weth10.balanceOf(user1)
         const toBalanceBefore = new BN(await web3.eth.getBalance(user2))
 
-        await weth.withdrawTo(user2, 1, { from: user1 })
+        await weth10.withdrawTo(user2, 1, { from: user1 })
 
-        const fromBalanceAfter = await weth.balanceOf(user1)
+        const fromBalanceAfter = await weth10.balanceOf(user1)
         const toBalanceAfter = new BN(await web3.eth.getBalance(user2))
 
         fromBalanceAfter.toString().should.equal(fromBalanceBefore.sub(new BN('1')).toString())
@@ -95,134 +98,187 @@ contract('WETH10', (accounts) => {
       })
 
       it('should not withdraw to the contract address', async () => {
-        await expectRevert(weth.withdrawTo(weth.address, 1, { from: user1 }), 'WETH::withdrawTo: invalid recipient')
-        await expectRevert(weth.withdrawFrom(user1, weth.address, 1, { from: user1 }), 'WETH::withdrawFrom: invalid recipient')
+        await expectRevert(weth10.withdrawTo(weth10.address, 1, { from: user1 }), 'WETH::withdrawTo: invalid recipient')
+        await expectRevert(weth10.withdrawFrom(user1, weth10.address, 1, { from: user1 }), 'WETH::withdrawFrom: invalid recipient')
       })
 
       it('should not withdraw beyond balance', async () => {
-        await expectRevert(weth.withdraw(100, { from: user1 }), 'WETH::withdraw: withdraw amount exceeds balance')
-        await expectRevert(weth.withdrawTo(user2, 100, { from: user1 }), 'WETH::withdrawTo: withdraw amount exceeds balance')
-        await expectRevert(weth.withdrawFrom(user1, user2, 100, { from: user1 }), 'WETH::withdrawFrom: withdraw amount exceeds balance')
+        await expectRevert(weth10.withdraw(100, { from: user1 }), 'WETH::withdraw: withdraw amount exceeds balance')
+        await expectRevert(weth10.withdrawTo(user2, 100, { from: user1 }), 'WETH::withdrawTo: withdraw amount exceeds balance')
+        await expectRevert(weth10.withdrawFrom(user1, user2, 100, { from: user1 }), 'WETH::withdrawFrom: withdraw amount exceeds balance')
+      })
+
+      it('converts weth10 to weth9', async () => {
+        const weth9Before = await weth9.balanceOf(user1)
+        const weth10Before = await weth10.balanceOf(user1)
+        await weth10.convert(1, { from: user1 })
+        const weth9After = await weth9.balanceOf(user1)
+        const weth10After = await weth10.balanceOf(user1)
+        weth9After.toString().should.equal(weth9Before.add(new BN('1')).toString())
+        weth10After.toString().should.equal(weth10Before.sub(new BN('1')).toString())
+      })
+
+      it('converts weth10 to weth9 into another account', async () => {
+        const fromBalanceBefore = await weth10.balanceOf(user1)
+        const toBalanceBefore = await weth9.balanceOf(user2)
+
+        await weth10.convertTo(user2, 1, { from: user1 })
+
+        const fromBalanceAfter = await weth10.balanceOf(user1)
+        const toBalanceAfter = await weth9.balanceOf(user2)
+
+        fromBalanceAfter.toString().should.equal(fromBalanceBefore.sub(new BN('1')).toString())
+        toBalanceAfter.toString().should.equal(toBalanceBefore.add(new BN('1')).toString())
+      })
+
+      it('should not convert weth10 to weth9 into the contract address', async () => {
+        await expectRevert(weth10.convertTo(weth10.address, 1, { from: user1 }), 'WETH::convertTo: invalid recipient')
+        await expectRevert(weth10.convertFrom(user1, weth10.address, 1, { from: user1 }), 'WETH::convertFrom: invalid recipient')
+      })
+
+      it('should not withdraw beyond balance', async () => {
+        await expectRevert(weth10.convert(100, { from: user1 }), 'WETH::convert: convert amount exceeds balance')
+        await expectRevert(weth10.convertTo(user2, 100, { from: user1 }), 'WETH::convertTo: convert amount exceeds balance')
+        await expectRevert(weth10.convertFrom(user1, user2, 100, { from: user1 }), 'WETH::convertFrom: convert amount exceeds balance')
       })
 
       it('transfers ether', async () => {
-        const balanceBefore = await weth.balanceOf(user2)
-        await weth.transfer(user2, 1, { from: user1 })
-        const balanceAfter = await weth.balanceOf(user2)
+        const balanceBefore = await weth10.balanceOf(user2)
+        await weth10.transfer(user2, 1, { from: user1 })
+        const balanceAfter = await weth10.balanceOf(user2)
         balanceAfter.toString().should.equal(balanceBefore.add(new BN('1')).toString())
       })
 
       it('transfers ether using transferFrom', async () => {
-        const balanceBefore = await weth.balanceOf(user2)
-        await weth.transferFrom(user1, user2, 1, { from: user1 })
-        const balanceAfter = await weth.balanceOf(user2)
+        const balanceBefore = await weth10.balanceOf(user2)
+        await weth10.transferFrom(user1, user2, 1, { from: user1 })
+        const balanceAfter = await weth10.balanceOf(user2)
         balanceAfter.toString().should.equal(balanceBefore.add(new BN('1')).toString())
       })
 
       it('transfers with transferAndCall', async () => {
         const receiver = await TestERC677Receiver.new()
-        await weth.transferAndCall(receiver.address, 1, '0x11', { from: user1 })
+        await weth10.transferAndCall(receiver.address, 1, '0x11', { from: user1 })
 
         const events = await receiver.getPastEvents()
         events.length.should.equal(1)
         events[0].event.should.equal('TransferReceived')
-        events[0].returnValues.token.should.equal(weth.address)
+        events[0].returnValues.token.should.equal(weth10.address)
         events[0].returnValues.sender.should.equal(user1)
         events[0].returnValues.value.should.equal('1')
         events[0].returnValues.data.should.equal('0x11')
       })
 
       it('should not transfer to the contract address', async () => {
-        await expectRevert(weth.transfer(weth.address, 1, { from: user1 }), 'WETH::transfer: invalid recipient')
-        await expectRevert(weth.transferFrom(user1, weth.address, 1, { from: user1 }), 'WETH::transferFrom: invalid recipient')
-        await expectRevert(weth.transferAndCall(weth.address, 1, '0x11', { from: user1 }), 'WETH::transferAndCall: invalid recipient')
+        await expectRevert(weth10.transfer(weth10.address, 1, { from: user1 }), 'WETH::transfer: invalid recipient')
+        await expectRevert(weth10.transferFrom(user1, weth10.address, 1, { from: user1 }), 'WETH::transferFrom: invalid recipient')
+        await expectRevert(weth10.transferAndCall(weth10.address, 1, '0x11', { from: user1 }), 'WETH::transferAndCall: invalid recipient')
       })
 
       it('should not transfer beyond balance', async () => {
-        await expectRevert(weth.transfer(user2, 100, { from: user1 }), 'WETH::transfer: transfer amount exceeds balance')
-        await expectRevert(weth.transferFrom(user1, user2, 100, { from: user1 }), 'WETH::transferFrom: transfer amount exceeds balance')
+        await expectRevert(weth10.transfer(user2, 100, { from: user1 }), 'WETH::transfer: transfer amount exceeds balance')
+        await expectRevert(weth10.transferFrom(user1, user2, 100, { from: user1 }), 'WETH::transferFrom: transfer amount exceeds balance')
         const receiver = await TestERC677Receiver.new()
-        await expectRevert(weth.transferAndCall(receiver.address, 100, '0x11', { from: user1 }), 'WETH::transferAndCall: transfer amount exceeds balance')
+        await expectRevert(weth10.transferAndCall(receiver.address, 100, '0x11', { from: user1 }), 'WETH::transferAndCall: transfer amount exceeds balance')
       })
 
       it('approves to increase allowance', async () => {
-        const allowanceBefore = await weth.allowance(user1, user2)
-        await weth.approve(user2, 1, { from: user1 })
-        const allowanceAfter = await weth.allowance(user1, user2)
+        const allowanceBefore = await weth10.allowance(user1, user2)
+        await weth10.approve(user2, 1, { from: user1 })
+        const allowanceAfter = await weth10.allowance(user1, user2)
         allowanceAfter.toString().should.equal(allowanceBefore.add(new BN('1')).toString())
       })
 
       it('approves to increase allowance with permit', async () => {
-        const permitResult = await signERC2612Permit(web3.currentProvider, weth.address, user1, user2, '1')
-        await weth.permit(user1, user2, '1', permitResult.deadline, permitResult.v, permitResult.r, permitResult.s)
-        const allowanceAfter = await weth.allowance(user1, user2)
+        const permitResult = await signERC2612Permit(web3.currentProvider, weth10.address, user1, user2, '1')
+        await weth10.permit(user1, user2, '1', permitResult.deadline, permitResult.v, permitResult.r, permitResult.s)
+        const allowanceAfter = await weth10.allowance(user1, user2)
         allowanceAfter.toString().should.equal('1')
       })
 
       it('does not approve with expired permit', async () => {
-        const permitResult = await signERC2612Permit(web3.currentProvider, weth.address, user1, user2, '1')
-        await expectRevert(weth.permit(
+        const permitResult = await signERC2612Permit(web3.currentProvider, weth10.address, user1, user2, '1')
+        await expectRevert(weth10.permit(
           user1, user2, '1', 0, permitResult.v, permitResult.r, permitResult.s),
           'WETH::permit: Expired permit'
         )
       })
 
       it('does not approve with invalid permit', async () => {
-        const permitResult = await signERC2612Permit(web3.currentProvider, weth.address, user1, user2, '1')
+        const permitResult = await signERC2612Permit(web3.currentProvider, weth10.address, user1, user2, '1')
         await expectRevert(
-          weth.permit(user1, user2, '2', permitResult.deadline, permitResult.v, permitResult.r, permitResult.s),
+          weth10.permit(user1, user2, '2', permitResult.deadline, permitResult.v, permitResult.r, permitResult.s),
           'WETH::permit: invalid permit'
         )
       })
 
       describe('with a positive allowance', async () => {
         beforeEach(async () => {
-          await weth.approve(user2, 1, { from: user1 })
+          await weth10.approve(user2, 1, { from: user1 })
         })
 
         it('transfers ether using transferFrom and allowance', async () => {
-          const balanceBefore = await weth.balanceOf(user2)
-          await weth.transferFrom(user1, user2, 1, { from: user2 })
-          const balanceAfter = await weth.balanceOf(user2)
+          const balanceBefore = await weth10.balanceOf(user2)
+          await weth10.transferFrom(user1, user2, 1, { from: user2 })
+          const balanceAfter = await weth10.balanceOf(user2)
           balanceAfter.toString().should.equal(balanceBefore.add(new BN('1')).toString())
         })
 
         it('should not transfer beyond allowance', async () => {
-          await expectRevert(weth.transferFrom(user1, user2, 2, { from: user2 }), 'WETH::transferFrom: transfer amount exceeds allowance')
+          await expectRevert(weth10.transferFrom(user1, user2, 2, { from: user2 }), 'WETH::transferFrom: transfer amount exceeds allowance')
         })
   
         it('withdraws ether using withdrawFrom and allowance', async () => {
-          const fromBalanceBefore = await weth.balanceOf(user1)
+          const fromBalanceBefore = await weth10.balanceOf(user1)
           const toBalanceBefore = new BN(await web3.eth.getBalance(user3))
 
-          await weth.withdrawFrom(user1, user3, 1, { from: user2 })
+          await weth10.withdrawFrom(user1, user3, 1, { from: user2 })
 
-          const fromBalanceAfter = await weth.balanceOf(user1)
+          const fromBalanceAfter = await weth10.balanceOf(user1)
           const toBalanceAfter = new BN(await web3.eth.getBalance(user3))
 
           fromBalanceAfter.toString().should.equal(fromBalanceBefore.sub(new BN('1')).toString())
           toBalanceAfter.toString().should.equal(toBalanceBefore.add(new BN('1')).toString())
         })
+  
+        it('converts weth10 to weth9 using convertFrom and allowance', async () => {
+          const fromBalanceBefore = await weth10.balanceOf(user1)
+          const toBalanceBefore = await weth9.balanceOf(user3)
 
-        it('should not transfer beyond allowance', async () => {
-          await expectRevert(weth.withdrawFrom(user1, user3, 2, { from: user2 }), 'WETH::withdrawFrom: withdraw amount exceeds allowance')
+          await weth10.convertFrom(user1, user3, 1, { from: user2 })
+
+          const fromBalanceAfter = await weth10.balanceOf(user1)
+          const toBalanceAfter = await weth9.balanceOf(user3)
+
+          fromBalanceAfter.toString().should.equal(fromBalanceBefore.sub(new BN('1')).toString())
+          toBalanceAfter.toString().should.equal(toBalanceBefore.add(new BN('1')).toString())
+        })
+
+        it('should not withdraw beyond allowance', async () => {
+          await expectRevert(weth10.withdrawFrom(user1, user3, 2, { from: user2 }), 'WETH::withdrawFrom: withdraw amount exceeds allowance')
         })
       })
 
       describe('with a maximum allowance', async () => {
         beforeEach(async () => {
-          await weth.approve(user2, MAX, { from: user1 })
+          await weth10.approve(user2, MAX, { from: user1 })
         })
 
         it('does not decrease allowance using transferFrom', async () => {
-          await weth.transferFrom(user1, user2, 1, { from: user2 })
-          const allowanceAfter = await weth.allowance(user1, user2)
+          await weth10.transferFrom(user1, user2, 1, { from: user2 })
+          const allowanceAfter = await weth10.allowance(user1, user2)
           allowanceAfter.toString().should.equal(MAX)
         })
 
         it('does not decrease allowance using withdrawFrom', async () => {
-          await weth.withdrawFrom(user1, user2, 1, { from: user2 })
-          const allowanceAfter = await weth.allowance(user1, user2)
+          await weth10.withdrawFrom(user1, user2, 1, { from: user2 })
+          const allowanceAfter = await weth10.allowance(user1, user2)
+          allowanceAfter.toString().should.equal(MAX)
+        })
+
+        it('does not decrease allowance using convertFrom', async () => {
+          await weth10.convertFrom(user1, user2, 1, { from: user2 })
+          const allowanceAfter = await weth10.allowance(user1, user2)
           allowanceAfter.toString().should.equal(MAX)
         })
       })

--- a/test/02_WETH10_Flash.test.js
+++ b/test/02_WETH10_Flash.test.js
@@ -1,3 +1,4 @@
+const WETH9 = artifacts.require('WETH9')
 const WETH10 = artifacts.require('WETH10')
 const TestFlashMinter = artifacts.require('TestFlashMinter')
 
@@ -8,18 +9,20 @@ const MAX = "5192296858534827628530496329220095"
 
 contract('WETH10 - Flash Minting', (accounts) => {
   const [deployer, user1, user2] = accounts
-  let weth
+  let weth9
+  let weth10
   let flash
 
   beforeEach(async () => {
-    weth = await WETH10.new({ from: deployer })
+    weth9 = await WETH9.new({ from: deployer })
+    weth10 = await WETH10.new(weth9.address, { from: deployer })
     flash = await TestFlashMinter.new({ from: deployer })
   })
 
   it('should do a simple flash mint', async () => {
-    await flash.flashMint(weth.address, 1, { from: user1 })
+    await flash.flashMint(weth10.address, 1, { from: user1 })
 
-    const balanceAfter = await weth.balanceOf(user1)
+    const balanceAfter = await weth10.balanceOf(user1)
     balanceAfter.toString().should.equal(new BN('0').toString())
     const flashBalance = await flash.flashBalance()
     flashBalance.toString().should.equal(new BN('1').toString())
@@ -30,26 +33,26 @@ contract('WETH10 - Flash Minting', (accounts) => {
   })
 
   it('cannot flash mint beyond the total supply limit', async () => {
-    await weth.deposit({ from: user1, value: '1' })
-    await expectRevert(flash.flashMint(weth.address, MAX, { from: user1 }), 'WETH::flashMint: supply limit exceeded')
+    await weth10.deposit({ from: user1, value: '1' })
+    await expectRevert(flash.flashMint(weth10.address, MAX, { from: user1 }), 'WETH::flashMint: supply limit exceeded')
   })
 
   it('should not steal a flash mint', async () => {
     await expectRevert(
-      flash.flashMintAndSteal(weth.address, 1, { from: deployer }),
+      flash.flashMintAndSteal(weth10.address, 1, { from: deployer }),
       'WETH::flashMint: transfer amount exceeds balance'
     )
   })
 
   it('needs to return funds after a flash mint', async () => {
     await expectRevert(
-      flash.flashMintAndOverspend(weth.address, 1, { from: user1 }),
+      flash.flashMintAndOverspend(weth10.address, 1, { from: user1 }),
       'WETH::flashMint: transfer amount exceeds balance'
     )
   })
 
   it('should do two nested flash loans', async () => {
-    await flash.flashMintAndReenter(weth.address, 1, { from: deployer })
+    await flash.flashMintAndReenter(weth10.address, 1, { from: deployer })
 
     const flashBalance = await flash.flashBalance()
     flashBalance.toString().should.equal('3')
@@ -57,11 +60,11 @@ contract('WETH10 - Flash Minting', (accounts) => {
 
   describe('with a non-zero WETH supply', () => {
     beforeEach(async () => {
-      await weth.deposit({ from: deployer, value: 10 })
+      await weth10.deposit({ from: deployer, value: 10 })
     })
 
     it('should flash mint, withdraw & deposit', async () => {
-      await flash.flashMintAndWithdraw(weth.address, 1, { from: deployer })
+      await flash.flashMintAndWithdraw(weth10.address, 1, { from: deployer })
 
       const flashBalance = await flash.flashBalance()
       flashBalance.toString().should.equal('1')


### PR DESCRIPTION
Functions to allow easy conversion of WETH10 into WETH9.

The idea is that these functions will reduce adoption risk, and liquidity fragmentation risk, even if just by a limited amount.