### PR TITLE
Embedded conversion functions - DO NOT MERGE

### DIFF
--- a/contracts/IWETH10.sol
+++ b/contracts/IWETH10.sol
@@ -58,19 +58,6 @@ interface IWETH10 is IERC20, IERC2612 {
     ///   - `from` account must have approved caller to spend at least `value` of WETH10 token, unless `from` and caller are the same account.
     function withdrawFrom(address from, address to, uint256 value) external;
 
-
-    /// @dev Exchange `value` WETH10 token from caller account for WETH9 token.
-    /// Emits {Transfer} event to reflect WETH10 token burn of `value` WETH10 token to zero address from caller account. 
-    /// Requirements:
-    ///   - caller account must have at least `value` balance of WETH10 token.
-    function convert(uint256 value) external;
-
-    /// @dev Exchange `value` WETH10 token from caller account for WETH9 token credited to account (`to`).
-    /// Emits {Transfer} event to reflect WETH10 token burn of `value` WETH10 token to zero address from caller account.
-    /// Requirements:
-    ///   - caller account must have at least `value` balance of WETH10 token.
-    function convertTo(address to, uint256 value) external;
-
     /// @dev Exchange `value` WETH10 token from account (`from`) for WETH9 token credited to account (`to`).
     /// Emits {Approval} event to reflect reduced allowance `value` for caller account to spend from account (`from`),
     /// unless allowance is set to `type(uint256).max`
@@ -78,8 +65,7 @@ interface IWETH10 is IERC20, IERC2612 {
     /// Requirements:
     ///   - `from` account must have at least `value` balance of WETH10 token.
     ///   - `from` account must have approved caller to spend at least `value` of WETH10 token, unless `from` and caller are the same account.
-    function convertFrom(address from, address to, uint256 value) external;
-
+    // function weth10ToWeth9(address weth9, address from, address to, uint256 value) external;
 
     /// @dev Moves `value` WETH10 token from caller's account to account (`to`), after which a call is executed to an ERC677-compliant contract.
     /// Returns boolean value indicating whether operation succeeded.

--- a/contracts/fuzzing/WETH10Fuzzing.sol
+++ b/contracts/fuzzing/WETH10Fuzzing.sol
@@ -18,7 +18,7 @@ contract WETH10Fuzzing {
 
     /// @dev Instantiate the WETH10 contract, and a holder address that will return weth when asked to.
     constructor () {
-        weth = new WETH10(address(0));
+        weth = new WETH10();
         holder = address(new MockHolder(address(weth), address(this)));
     }
 

--- a/contracts/tests/WETH9.sol
+++ b/contracts/tests/WETH9.sol
@@ -39,7 +39,7 @@ contract WETH9 {
     function withdraw(uint wad) public {
         require(balanceOf[msg.sender] >= wad);
         balanceOf[msg.sender] -= wad;
-        msg.sender.transfer(wad);
+        msg.sender.call{ value: wad }("");
         emit Withdrawal(msg.sender, wad);
     }
 


### PR DESCRIPTION
This PR is just a draft showing that a weth9 to weth10 function can't be coded inside weth10.sol.

In such a function, weth10 would have to `weth9.withdraw`, which does `address(weth10).transfer`, which calls back at `weth10.receive`.

Unfortunately, `address.transfer` sends 2300 gas, and `weth10.receive` uses more than that.

There seems to be no way for a contract to `withdraw` from weth9 and do something as a result.