### PR TITLE
Feat/refactor conversions

### DIFF
--- a/contracts/IWETH10.sol
+++ b/contracts/IWETH10.sol
@@ -58,29 +58,6 @@ interface IWETH10 is IERC20, IERC2612 {
     ///   - `from` account must have approved caller to spend at least `value` of WETH10 token, unless `from` and caller are the same account.
     function withdrawFrom(address from, address to, uint256 value) external;
 
-
-    /// @dev Exchange `value` WETH10 token from caller account for WETH9 token.
-    /// Emits {Transfer} event to reflect WETH10 token burn of `value` WETH10 token to zero address from caller account. 
-    /// Requirements:
-    ///   - caller account must have at least `value` balance of WETH10 token.
-    function convert(uint256 value) external;
-
-    /// @dev Exchange `value` WETH10 token from caller account for WETH9 token credited to account (`to`).
-    /// Emits {Transfer} event to reflect WETH10 token burn of `value` WETH10 token to zero address from caller account.
-    /// Requirements:
-    ///   - caller account must have at least `value` balance of WETH10 token.
-    function convertTo(address to, uint256 value) external;
-
-    /// @dev Exchange `value` WETH10 token from account (`from`) for WETH9 token credited to account (`to`).
-    /// Emits {Approval} event to reflect reduced allowance `value` for caller account to spend from account (`from`),
-    /// unless allowance is set to `type(uint256).max`
-    /// Emits {Transfer} event to reflect WETH10 token burn of `value` to zero address from account (`from`).
-    /// Requirements:
-    ///   - `from` account must have at least `value` balance of WETH10 token.
-    ///   - `from` account must have approved caller to spend at least `value` of WETH10 token, unless `from` and caller are the same account.
-    function convertFrom(address from, address to, uint256 value) external;
-
-
     /// @dev Moves `value` WETH10 token from caller's account to account (`to`), after which a call is executed to an ERC677-compliant contract.
     /// Returns boolean value indicating whether operation succeeded.
     /// Emits {Transfer} event.

--- a/contracts/WETH10.sol
+++ b/contracts/WETH10.sol
@@ -30,9 +30,6 @@ contract WETH10 is IWETH10 {
 
     bytes32 public immutable PERMIT_TYPEHASH = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
 
-    /// @dev WETH9 contract
-    WETH9Like public immutable weth9;
-
     /// @dev Records amount of WETH10 token owned by account.
     mapping (address => uint256) public override balanceOf;
 
@@ -45,11 +42,6 @@ contract WETH10 is IWETH10 {
 
     /// @dev Current amount of flash minted WETH.
     uint256 public override flashSupply;
-
-    /// @dev The constructor takes the address of the WETH9 contract to allow conversions
-    constructor (address weth9_) {
-        weth9 = WETH9Like(weth9_);
-    }
 
     /// @dev Fallback, `msg.value` of ether sent to contract grants caller account a matching increase in WETH10 token balance.
     /// Emits {Transfer} event to reflect WETH10 token mint of `msg.value` from zero address to caller account.
@@ -171,62 +163,6 @@ contract WETH10 is IWETH10 {
         require(success, "WETH::withdrawFrom: Ether transfer failed");
 
         emit Transfer(from, address(0), value);
-    }
-
-    /// @dev Exchange `value` WETH10 token from caller account for WETH9 token.
-    /// Emits {Transfer} event to reflect WETH10 token burn of `value` WETH10 token to zero address from caller account. 
-    /// Requirements:
-    ///   - caller account must have at least `value` balance of WETH10 token.
-    function convert(uint256 value) external override {
-        require(balanceOf[msg.sender] >= value, "WETH::convert: convert amount exceeds balance");
-        balanceOf[msg.sender] -= value;
-
-        emit Transfer(msg.sender, address(0), value);
-
-        weth9.deposit{value: value}();
-        require(weth9.transfer(msg.sender, value), "WETH::convert: WETH transfer failed");
-    }
-
-    /// @dev Exchange `value` WETH10 token from caller account for WETH9 token credited to account (`to`).
-    /// Emits {Transfer} event to reflect WETH10 token burn of `value` WETH10 token to zero address from caller account.
-    /// Requirements:
-    ///   - caller account must have at least `value` balance of WETH10 token.
-    function convertTo(address to, uint256 value) external override {
-        require(balanceOf[msg.sender] >= value, "WETH::convertTo: convert amount exceeds balance");
-        require(to != address(this), "WETH::convertTo: invalid recipient");
-        balanceOf[msg.sender] -= value;
-
-        emit Transfer(msg.sender, address(0), value);
-    
-        weth9.deposit{value: value}();
-        require(weth9.transfer(to, value), "WETH::convert: WETH transfer failed");
-    }
-
-    /// @dev Exchange `value` WETH10 token from account (`from`) for WETH9 token credited to account (`to`).
-    /// Emits {Approval} event to reflect reduced allowance `value` for caller account to spend from account (`from`),
-    /// unless allowance is set to `type(uint256).max`
-    /// Emits {Transfer} event to reflect WETH10 token burn of `value` to zero address from account (`from`).
-    /// Requirements:
-    ///   - `from` account must have at least `value` balance of WETH10 token.
-    ///   - `from` account must have approved caller to spend at least `value` of WETH10 token, unless `from` and caller are the same account.
-    function convertFrom(address from, address to, uint256 value) external override {
-        require(balanceOf[from] >= value, "WETH::convertFrom: convert amount exceeds balance");
-        require(to != address(this), "WETH::convertFrom: invalid recipient");
-        
-        if (from != msg.sender) {
-            uint256 allowed = allowance[from][msg.sender];
-            if (allowed != type(uint256).max) {
-                require(allowed >= value, "WETH::convertFrom: convert amount exceeds allowance");
-                allowance[from][msg.sender] = allowed - value;
-                emit Approval(from, msg.sender, allowed - value);
-            }
-        }
-        balanceOf[from] -= value;
-
-        emit Transfer(from, address(0), value);
-
-        weth9.deposit{value: value}();
-        require(weth9.transfer(to, value), "WETH::convert: WETH transfer failed");
     }
 
     /// @dev Sets `value` as allowance of `spender` account over caller account's WETH10 token.

--- a/contracts/WethConverter.sol
+++ b/contracts/WethConverter.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2015, 2016, 2017 Dapphub
+// Adapted by Ethereum Community 2020
+pragma solidity 0.7.0;
+
+
+interface WETH9Like {
+    function withdraw(uint) external payable;
+    function deposit() external payable;
+    function transfer(address, uint) external returns (bool);
+    function transferFrom(address, address, uint) external returns (bool);
+}
+
+interface WETH10Like {
+    function depositTo(address) external payable;
+    function withdrawFrom(address, address, uint256) external payable;
+}
+
+contract WethConverter {
+
+    receive() external payable {
+    }
+
+    function weth9ToWeth10(WETH9Like weth9, WETH10Like weth10, address account, uint256 value) public {
+        weth9.transferFrom(account, address(this), value);
+        weth9.withdraw(value);
+        weth10.depositTo{ value: value }(account);
+    }
+
+    function weth10ToWeth9(WETH9Like weth9, WETH10Like weth10, address account, uint256 value) public {
+        weth10.withdrawFrom(account, address(this), value);
+        weth9.deposit{ value: value }();
+        weth9.transfer(account, value);
+    }
+}
+

--- a/contracts/fuzzing/WETH10Fuzzing.sol
+++ b/contracts/fuzzing/WETH10Fuzzing.sol
@@ -18,7 +18,7 @@ contract WETH10Fuzzing {
 
     /// @dev Instantiate the WETH10 contract, and a holder address that will return weth when asked to.
     constructor () {
-        weth = new WETH10(address(0));
+        weth = new WETH10();
         holder = address(new MockHolder(address(weth), address(this)));
     }
 

--- a/test/01_WETH10.test.js
+++ b/test/01_WETH10.test.js
@@ -108,40 +108,6 @@ contract('WETH10', (accounts) => {
         await expectRevert(weth10.withdrawFrom(user1, user2, 100, { from: user1 }), 'WETH::withdrawFrom: withdraw amount exceeds balance')
       })
 
-      it('converts weth10 to weth9', async () => {
-        const weth9Before = await weth9.balanceOf(user1)
-        const weth10Before = await weth10.balanceOf(user1)
-        await weth10.convert(1, { from: user1 })
-        const weth9After = await weth9.balanceOf(user1)
-        const weth10After = await weth10.balanceOf(user1)
-        weth9After.toString().should.equal(weth9Before.add(new BN('1')).toString())
-        weth10After.toString().should.equal(weth10Before.sub(new BN('1')).toString())
-      })
-
-      it('converts weth10 to weth9 into another account', async () => {
-        const fromBalanceBefore = await weth10.balanceOf(user1)
-        const toBalanceBefore = await weth9.balanceOf(user2)
-
-        await weth10.convertTo(user2, 1, { from: user1 })
-
-        const fromBalanceAfter = await weth10.balanceOf(user1)
-        const toBalanceAfter = await weth9.balanceOf(user2)
-
-        fromBalanceAfter.toString().should.equal(fromBalanceBefore.sub(new BN('1')).toString())
-        toBalanceAfter.toString().should.equal(toBalanceBefore.add(new BN('1')).toString())
-      })
-
-      it('should not convert weth10 to weth9 into the contract address', async () => {
-        await expectRevert(weth10.convertTo(weth10.address, 1, { from: user1 }), 'WETH::convertTo: invalid recipient')
-        await expectRevert(weth10.convertFrom(user1, weth10.address, 1, { from: user1 }), 'WETH::convertFrom: invalid recipient')
-      })
-
-      it('should not withdraw beyond balance', async () => {
-        await expectRevert(weth10.convert(100, { from: user1 }), 'WETH::convert: convert amount exceeds balance')
-        await expectRevert(weth10.convertTo(user2, 100, { from: user1 }), 'WETH::convertTo: convert amount exceeds balance')
-        await expectRevert(weth10.convertFrom(user1, user2, 100, { from: user1 }), 'WETH::convertFrom: convert amount exceeds balance')
-      })
-
       it('transfers ether', async () => {
         const balanceBefore = await weth10.balanceOf(user2)
         await weth10.transfer(user2, 1, { from: user1 })
@@ -240,19 +206,6 @@ contract('WETH10', (accounts) => {
           fromBalanceAfter.toString().should.equal(fromBalanceBefore.sub(new BN('1')).toString())
           toBalanceAfter.toString().should.equal(toBalanceBefore.add(new BN('1')).toString())
         })
-  
-        it('converts weth10 to weth9 using convertFrom and allowance', async () => {
-          const fromBalanceBefore = await weth10.balanceOf(user1)
-          const toBalanceBefore = await weth9.balanceOf(user3)
-
-          await weth10.convertFrom(user1, user3, 1, { from: user2 })
-
-          const fromBalanceAfter = await weth10.balanceOf(user1)
-          const toBalanceAfter = await weth9.balanceOf(user3)
-
-          fromBalanceAfter.toString().should.equal(fromBalanceBefore.sub(new BN('1')).toString())
-          toBalanceAfter.toString().should.equal(toBalanceBefore.add(new BN('1')).toString())
-        })
 
         it('should not withdraw beyond allowance', async () => {
           await expectRevert(weth10.withdrawFrom(user1, user3, 2, { from: user2 }), 'WETH::withdrawFrom: withdraw amount exceeds allowance')
@@ -272,12 +225,6 @@ contract('WETH10', (accounts) => {
 
         it('does not decrease allowance using withdrawFrom', async () => {
           await weth10.withdrawFrom(user1, user2, 1, { from: user2 })
-          const allowanceAfter = await weth10.allowance(user1, user2)
-          allowanceAfter.toString().should.equal(MAX)
-        })
-
-        it('does not decrease allowance using convertFrom', async () => {
-          await weth10.convertFrom(user1, user2, 1, { from: user2 })
           const allowanceAfter = await weth10.allowance(user1, user2)
           allowanceAfter.toString().should.equal(MAX)
         })

--- a/test/03_WethConverter.test.js
+++ b/test/03_WethConverter.test.js
@@ -1,0 +1,37 @@
+const WETH9 = artifacts.require('WETH9')
+const WETH10 = artifacts.require('WETH10')
+const WethConverter = artifacts.require('WethConverter')
+
+const { BN, expectRevert } = require('@openzeppelin/test-helpers')
+const { web3 } = require('@openzeppelin/test-helpers/src/setup')
+require('chai').use(require('chai-as-promised')).should()
+
+contract('WethConverter', (accounts) => {
+  const [deployer, user1, user2, user3] = accounts
+  let weth9, weth10, wethConverter
+
+  beforeEach(async () => {
+    weth9 = await WETH9.new({ from: deployer })
+    weth10 = await WETH10.new({ from: deployer })
+    wethConverter = await WethConverter.new({ from: deployer })
+
+    await weth9.deposit({ from: user1, value: 1 })
+    await weth10.deposit({ from: user2, value: 1 })
+  })
+
+  describe('deployment', async () => {
+    it('converts from weth9 to weth10', async () => {
+      await weth9.approve(wethConverter.address, 1, { from: user1 })
+      await wethConverter.weth9ToWeth10(weth9.address, weth10.address, user1, 1, { from: user1 })
+      const balanceAfter = await weth10.balanceOf(user1)
+      balanceAfter.toString().should.equal('1')
+    })
+
+    it('converts from weth10 to weth9', async () => {
+      await weth10.approve(wethConverter.address, 1, { from: user2 })
+      await wethConverter.weth10ToWeth9(weth9.address, weth10.address, user2, 1, { from: user2 })
+      const balanceAfter = await weth9.balanceOf(user2)
+      balanceAfter.toString().should.equal('1')
+    })
+  })
+})


### PR DESCRIPTION
Extracted conversion functions into an external contract.

Overall gas usage in `weth10ToWeth9` is higher than in the older `convertFrom`. `weth10ToWeth9` requires a prior `approve` so the cost is about 100K in two transactions.

Gas usage of `weth9ToWeth10` is also 100K in two transactions.