### PR TITLE
feat: transfers to zero address

### DIFF
--- a/contracts/WETH10.sol
+++ b/contracts/WETH10.sol
@@ -223,6 +223,7 @@ contract WETH10 is IWETH10 {
     }
 
     /// @dev Moves `value` WETH10 token from caller's account to account (`to`).
+    /// A transfer to `address(0)` or `address(WETH10)` triggers a withdraw of the sent tokens.
     /// Returns boolean value indicating whether operation succeeded.
     /// Emits {Transfer} event.
     /// Requirements:
@@ -230,10 +231,15 @@ contract WETH10 is IWETH10 {
     function transfer(address to, uint256 value) external override returns (bool) {
         uint256 balance = balanceOf[msg.sender];
         require(balance >= value, "WETH::transfer: transfer amount exceeds balance");
-        require(to != address(this), "WETH::transfer: invalid recipient");
-
+        
         balanceOf[msg.sender] = balance - value;
-        balanceOf[to] += value;
+
+        if(to == address(0) || to == address(this)) { // Withdraw
+            (bool success, ) = msg.sender.call{value: value}("");
+            require(success, "WETH::transfer: Ether transfer failed");
+        } else { // Transfer
+            balanceOf[to] += value;
+        }
 
         emit Transfer(msg.sender, to, value);
 
@@ -242,6 +248,7 @@ contract WETH10 is IWETH10 {
 
     /// @dev Moves `value` WETH10 token from account (`from`) to account (`to`) using allowance mechanism.
     /// `value` is then deducted from caller account's allowance, unless set to `type(uint256).max`.
+    /// A transfer to `address(0)` or `address(WETH10)` triggers a withdraw of the sent tokens in favor of caller.
     /// Returns boolean value indicating whether operation succeeded.
     ///
     /// Emits {Transfer} and {Approval} events.
@@ -251,7 +258,6 @@ contract WETH10 is IWETH10 {
     function transferFrom(address from, address to, uint256 value) external override returns (bool) {
         uint256 balance = balanceOf[from];
         require(balance >= value, "WETH::transferFrom: transfer amount exceeds balance");
-        require(to != address(this), "WETH::transferFrom: invalid recipient");
 
         if (from != msg.sender) {
             uint256 allowed = allowance[from][msg.sender];
@@ -263,7 +269,13 @@ contract WETH10 is IWETH10 {
         }
 
         balanceOf[from] = balance - value;
-        balanceOf[to] += value;
+        
+        if(to == address(0) || to == address(this)) { // Withdraw
+            (bool success, ) = msg.sender.call{value: value}("");
+            require(success, "WETH::transferFrom: Ether transfer failed");
+        } else { // Transfer
+            balanceOf[to] += value;
+        }
 
         emit Transfer(from, to, value);
 
@@ -276,12 +288,13 @@ contract WETH10 is IWETH10 {
     /// Requirements:
     ///   - caller account must have at least `value` WETH10 token.
     /// For more information on transferAndCall format, see https://github.com/ethereum/EIPs/issues/677.
-    function transferAndCall(address to, uint value, bytes calldata data) external override returns (bool success) {
+    function transferAndCall(address to, uint value, bytes calldata data) external override returns (bool) {
         uint256 balance = balanceOf[msg.sender];
         require(balance >= value, "WETH::transferAndCall: transfer amount exceeds balance");
-        require(to != address(this), "WETH::transferAndCall: invalid recipient");
+        // Transfers to address(0) or address(this) will fail on the ERC677 call
 
         balanceOf[msg.sender] = balance - value;
+        
         balanceOf[to] += value;
 
         emit Transfer(msg.sender, to, value);

--- a/contracts/WETH10.sol
+++ b/contracts/WETH10.sol
@@ -223,7 +223,7 @@ contract WETH10 is IWETH10 {
     }
 
     /// @dev Moves `value` WETH10 token from caller's account to account (`to`).
-    /// A transfer to `address(0)` or `address(WETH10)` triggers a withdraw of the sent tokens.
+    /// A transfer to `address(0)` triggers a withdraw of the sent tokens.
     /// Returns boolean value indicating whether operation succeeded.
     /// Emits {Transfer} event.
     /// Requirements:
@@ -234,7 +234,7 @@ contract WETH10 is IWETH10 {
         
         balanceOf[msg.sender] = balance - value;
 
-        if(to == address(0) || to == address(this)) { // Withdraw
+        if(to == address(0)) { // Withdraw
             (bool success, ) = msg.sender.call{value: value}("");
             require(success, "WETH::transfer: Ether transfer failed");
         } else { // Transfer
@@ -248,7 +248,7 @@ contract WETH10 is IWETH10 {
 
     /// @dev Moves `value` WETH10 token from account (`from`) to account (`to`) using allowance mechanism.
     /// `value` is then deducted from caller account's allowance, unless set to `type(uint256).max`.
-    /// A transfer to `address(0)` or `address(WETH10)` triggers a withdraw of the sent tokens in favor of caller.
+    /// A transfer to `address(0)` triggers a withdraw of the sent tokens in favor of caller.
     /// Returns boolean value indicating whether operation succeeded.
     ///
     /// Emits {Transfer} and {Approval} events.
@@ -270,7 +270,7 @@ contract WETH10 is IWETH10 {
 
         balanceOf[from] = balance - value;
         
-        if(to == address(0) || to == address(this)) { // Withdraw
+        if(to == address(0)) { // Withdraw
             (bool success, ) = msg.sender.call{value: value}("");
             require(success, "WETH::transferFrom: Ether transfer failed");
         } else { // Transfer
@@ -291,7 +291,7 @@ contract WETH10 is IWETH10 {
     function transferAndCall(address to, uint value, bytes calldata data) external override returns (bool) {
         uint256 balance = balanceOf[msg.sender];
         require(balance >= value, "WETH::transferAndCall: transfer amount exceeds balance");
-        // Transfers to address(0) or address(this) will fail on the ERC677 call
+        // Transfers to address(0) will fail on the ERC677 call
 
         balanceOf[msg.sender] = balance - value;
         

--- a/contracts/tests/TestFlashMinter.sol
+++ b/contracts/tests/TestFlashMinter.sol
@@ -34,7 +34,7 @@ contract TestFlashMinter {
         } else if (action == Action.REENTER) {
             flashMint(msg.sender, value * 2);
         } else if (action == Action.OVERSPEND) {
-            FlashMintableLike(msg.sender).transfer(address(0), 1);
+            FlashMintableLike(msg.sender).transfer(address(1), 1);
         }
     }
 

--- a/test/01_WETH10.test.js
+++ b/test/01_WETH10.test.js
@@ -122,13 +122,6 @@ contract('WETH10', (accounts) => {
         balanceAfter.toString().should.equal(balanceBefore.sub(new BN('1')).toString())
       })
 
-      it('withdraws ether by transferring to weth contract', async () => {
-        const balanceBefore = await weth10.balanceOf(user1)
-        await weth10.transfer(weth10.address, 1, { from: user1 })
-        const balanceAfter = await weth10.balanceOf(user1)
-        balanceAfter.toString().should.equal(balanceBefore.sub(new BN('1')).toString())
-      })
-
       it('transfers ether using transferFrom', async () => {
         const balanceBefore = await weth10.balanceOf(user2)
         await weth10.transferFrom(user1, user2, 1, { from: user1 })
@@ -139,13 +132,6 @@ contract('WETH10', (accounts) => {
       it('withdraws ether by transferring from someone to address(0)', async () => {
         const balanceBefore = await weth10.balanceOf(user1)
         await weth10.transferFrom(user1, '0x0000000000000000000000000000000000000000', 1, { from: user1 })
-        const balanceAfter = await weth10.balanceOf(user1)
-        balanceAfter.toString().should.equal(balanceBefore.sub(new BN('1')).toString())
-      })
-
-      it('withdraws ether by transferring from someone to weth contract', async () => {
-        const balanceBefore = await weth10.balanceOf(user1)
-        await weth10.transferFrom(user1, weth10.address, 1, { from: user1 })
         const balanceAfter = await weth10.balanceOf(user1)
         balanceAfter.toString().should.equal(balanceBefore.sub(new BN('1')).toString())
       })

--- a/test/01_WETH10.test.js
+++ b/test/01_WETH10.test.js
@@ -115,11 +115,39 @@ contract('WETH10', (accounts) => {
         balanceAfter.toString().should.equal(balanceBefore.add(new BN('1')).toString())
       })
 
+      it('withdraws ether by transferring to address(0)', async () => {
+        const balanceBefore = await weth10.balanceOf(user1)
+        await weth10.transfer('0x0000000000000000000000000000000000000000', 1, { from: user1 })
+        const balanceAfter = await weth10.balanceOf(user1)
+        balanceAfter.toString().should.equal(balanceBefore.sub(new BN('1')).toString())
+      })
+
+      it('withdraws ether by transferring to weth contract', async () => {
+        const balanceBefore = await weth10.balanceOf(user1)
+        await weth10.transfer(weth10.address, 1, { from: user1 })
+        const balanceAfter = await weth10.balanceOf(user1)
+        balanceAfter.toString().should.equal(balanceBefore.sub(new BN('1')).toString())
+      })
+
       it('transfers ether using transferFrom', async () => {
         const balanceBefore = await weth10.balanceOf(user2)
         await weth10.transferFrom(user1, user2, 1, { from: user1 })
         const balanceAfter = await weth10.balanceOf(user2)
         balanceAfter.toString().should.equal(balanceBefore.add(new BN('1')).toString())
+      })
+
+      it('withdraws ether by transferring from someone to address(0)', async () => {
+        const balanceBefore = await weth10.balanceOf(user1)
+        await weth10.transferFrom(user1, '0x0000000000000000000000000000000000000000', 1, { from: user1 })
+        const balanceAfter = await weth10.balanceOf(user1)
+        balanceAfter.toString().should.equal(balanceBefore.sub(new BN('1')).toString())
+      })
+
+      it('withdraws ether by transferring from someone to weth contract', async () => {
+        const balanceBefore = await weth10.balanceOf(user1)
+        await weth10.transferFrom(user1, weth10.address, 1, { from: user1 })
+        const balanceAfter = await weth10.balanceOf(user1)
+        balanceAfter.toString().should.equal(balanceBefore.sub(new BN('1')).toString())
       })
 
       it('transfers with transferAndCall', async () => {
@@ -135,11 +163,11 @@ contract('WETH10', (accounts) => {
         events[0].returnValues.data.should.equal('0x11')
       })
 
-      it('should not transfer to the contract address', async () => {
+      /* it('should not transfer to the contract address', async () => {
         await expectRevert(weth10.transfer(weth10.address, 1, { from: user1 }), 'WETH::transfer: invalid recipient')
         await expectRevert(weth10.transferFrom(user1, weth10.address, 1, { from: user1 }), 'WETH::transferFrom: invalid recipient')
         await expectRevert(weth10.transferAndCall(weth10.address, 1, '0x11', { from: user1 }), 'WETH::transferAndCall: invalid recipient')
-      })
+      }) */
 
       it('should not transfer beyond balance', async () => {
         await expectRevert(weth10.transfer(user2, 100, { from: user1 }), 'WETH::transfer: transfer amount exceeds balance')


### PR DESCRIPTION
Taking a cue from USM, transfers to the zero address trigger a withdraw, instead of reverting.

The logic is that sending Ether to WETH10 credits WETH to the caller. Now sending WETH to 0 credits Ether to the caller.

This makes it possible to fully interact with WETH10 using only plain transfers in metamask, while also avoiding locking tokens in address(0)

Fixes #74, as now a `Transfer(user, 0, value)` always means a withdraw.