### PR TITLE
feat: approve and call

### DIFF
--- a/contracts/IWETH10.sol
+++ b/contracts/IWETH10.sol
@@ -29,7 +29,15 @@ interface IWETH10 is IERC20, IERC2612 {
     /// Requirements:
     ///   - caller account must have at least `value` WETH10 token and transfer to account (`to`) cannot cause overflow.
     /// For more information on transferAndCall format, see https://github.com/ethereum/EIPs/issues/677.
-    function depositToAndCall(address to, bytes calldata data) external payable returns (bool success);
+    function depositToAndCall(address to, bytes calldata data) external payable returns (bool);
+
+
+    /// @dev Sets `value` as allowance of `spender` account over caller account's WETH10 token,
+    /// after which a call is executed on `spender` with the `data` parameter.
+    /// Returns boolean value indicating whether operation succeeded.
+    /// Emits {Approval} event.
+    /// For more information on approveAndCall format, see https://github.com/ethereum/EIPs/issues/677.
+    function approveAndCall(address spender, uint256 value, bytes calldata data) external returns (bool);
 
     /// @dev Flash mints WETH10 token and burns from caller account.
     /// The flash minted WETH10 is not backed by real Ether, but can be withdrawn as such up to the Ether balance of this contract.
@@ -64,6 +72,6 @@ interface IWETH10 is IERC20, IERC2612 {
     /// Requirements:
     ///   - caller account must have at least `value` WETH10 token.
     /// For more information on transferAndCall format, see https://github.com/ethereum/EIPs/issues/677.
-    function transferAndCall(address to, uint value, bytes calldata data) external returns (bool success);
+    function transferAndCall(address to, uint value, bytes calldata data) external returns (bool);
 }
 

--- a/contracts/tests/TestERC677Receiver.sol
+++ b/contracts/tests/TestERC677Receiver.sol
@@ -3,12 +3,17 @@
 pragma solidity 0.7.0;
 
 
-contract TestERC677Receiver {
+contract TestTransferReceiver {
     address public token;
 
     event TransferReceived(address token, address sender, uint256 value, bytes data);
+    event ApprovalReceived(address token, address spender, uint256 value, bytes data);
 
     function onTokenTransfer(address sender, uint value, bytes calldata data) external {
         emit TransferReceived(msg.sender, sender, value, data);
+    }
+
+    function onTokenApproval(address spender, uint value, bytes calldata data) external {
+        emit ApprovalReceived(msg.sender, spender, value, data);
     }
 }

--- a/test/01_WETH10.test.js
+++ b/test/01_WETH10.test.js
@@ -1,7 +1,7 @@
 const WETH9 = artifacts.require('WETH9')
 const WETH10 = artifacts.require('WETH10')
 const { signERC2612Permit } = require('eth-permit')
-const TestERC677Receiver = artifacts.require('TestERC677Receiver')
+const TestTransferReceiver = artifacts.require('TestTransferReceiver')
 
 const { BN, expectRevert } = require('@openzeppelin/test-helpers')
 const { web3 } = require('@openzeppelin/test-helpers/src/setup')
@@ -55,7 +55,7 @@ contract('WETH10', (accounts) => {
     })
 
     it('deposits with depositToAndCall', async () => {
-      const receiver = await TestERC677Receiver.new()
+      const receiver = await TestTransferReceiver.new()
       await weth10.depositToAndCall(receiver.address, '0x11', { from: user1, value: 1 })
 
       const events = await receiver.getPastEvents()
@@ -123,7 +123,7 @@ contract('WETH10', (accounts) => {
       })
 
       it('transfers with transferAndCall', async () => {
-        const receiver = await TestERC677Receiver.new()
+        const receiver = await TestTransferReceiver.new()
         await weth10.transferAndCall(receiver.address, 1, '0x11', { from: user1 })
 
         const events = await receiver.getPastEvents()
@@ -144,7 +144,7 @@ contract('WETH10', (accounts) => {
       it('should not transfer beyond balance', async () => {
         await expectRevert(weth10.transfer(user2, 100, { from: user1 }), 'WETH::transfer: transfer amount exceeds balance')
         await expectRevert(weth10.transferFrom(user1, user2, 100, { from: user1 }), 'WETH::transferFrom: transfer amount exceeds balance')
-        const receiver = await TestERC677Receiver.new()
+        const receiver = await TestTransferReceiver.new()
         await expectRevert(weth10.transferAndCall(receiver.address, 100, '0x11', { from: user1 }), 'WETH::transferAndCall: transfer amount exceeds balance')
       })
 
@@ -153,6 +153,19 @@ contract('WETH10', (accounts) => {
         await weth10.approve(user2, 1, { from: user1 })
         const allowanceAfter = await weth10.allowance(user1, user2)
         allowanceAfter.toString().should.equal(allowanceBefore.add(new BN('1')).toString())
+      })
+
+      it('approves with approveAndCall', async () => {
+        const receiver = await TestTransferReceiver.new()
+        await weth10.approveAndCall(receiver.address, 1, '0x11', { from: user1 })
+
+        const events = await receiver.getPastEvents()
+        events.length.should.equal(1)
+        events[0].event.should.equal('ApprovalReceived')
+        events[0].returnValues.token.should.equal(weth10.address)
+        events[0].returnValues.spender.should.equal(user1)
+        events[0].returnValues.value.should.equal('1')
+        events[0].returnValues.data.should.equal('0x11')
       })
 
       it('approves to increase allowance with permit', async () => {


### PR DESCRIPTION
After carefully reviewing the existing discussion and alternatives, I thought that adding an `approveAndCall` function was reasonable, with no downside.

`transferAndCall` is a superior method, if just for the reason that it requires less storage ops, and the point of it is breaking from the `approve` and `transfer` pattern.

Plenty of other methods have been suggested, but in my opinion it is enough to offer in WETH10 the `permit` and the `andCall` patterns. If anything, a `withdrawAndCall` might be considered.

Fixes #73 