### PR TITLE
Refactor flash minting to proposed standard interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,7 @@ The `depositAndCall` and `transferAndCall` functions allow to deposit Ether or t
 
 This function will call `onTokenTransfer` on the recipient address, receiving and passing along a `bytes` parameter which can be used by the calling contract to process the callback. See [EIP667](https://github.com/ethereum/EIPs/issues/677).
 
-## Flash Minting
-This contract allows to `flashMint` an arbitrary amount of Wrapped Ether, unbacked by real Ether, with the condition that it is burned before the end of the transaction. 
+## Flash Loans
+This contract allows to `flashLoan` an arbitrary amount of Wrapped Ether, unbacked by real Ether, with the condition that it is burned before the end of the transaction. No fees are charged.
 
-This function will call `executeOnFlashMint` on the calling address, receiving and passing along a `bytes` parameter which can be used by the calling contract to process the callback.
-
-## Convert to WETH9
-This contract allows to convert WETH10 into WETH9 at a minimal cost, using `convert` functions. Combining `convertFrom` with `permit` this conversion can be done at no cost to the WETH10 holder.
+This function will call `onFlashLoan` on the calling address, receiving and passing along a `bytes` parameter which can be used by the calling contract to process the callback.

--- a/contracts/IWETH10.sol
+++ b/contracts/IWETH10.sol
@@ -35,7 +35,7 @@ interface IWETH10 is IERC20, IERC2612 {
     /// The flash minted WETH10 is not backed by real Ether, but can be withdrawn as such up to the Ether balance of this contract.
     /// Arbitrary data can be passed as a bytes calldata parameter.
     /// Emits two {Transfer} events for minting and burning of the flash minted amount.
-    function flashMint(address receiver, uint256 value, bytes calldata data) external;
+    function flashLoan(address receiver, uint256 value, bytes calldata data) external;
 
     /// @dev Burn `value` WETH10 token from caller account and withdraw matching ether to the same.
     /// Emits {Transfer} event to reflect WETH10 token burn of `value` WETH10 token to zero address from caller account. 

--- a/contracts/IWETH10.sol
+++ b/contracts/IWETH10.sol
@@ -31,11 +31,11 @@ interface IWETH10 is IERC20, IERC2612 {
     /// For more information on transferAndCall format, see https://github.com/ethereum/EIPs/issues/677.
     function depositToAndCall(address to, bytes calldata data) external payable returns (bool success);
 
-    /// @dev Flash mints WETH10 token and burns from caller account.
+    /// @dev Flash mints WETH10 token, which needs to be returned to the WETH10 contract to resolve.
     /// The flash minted WETH10 is not backed by real Ether, but can be withdrawn as such up to the Ether balance of this contract.
     /// Arbitrary data can be passed as a bytes calldata parameter.
     /// Emits two {Transfer} events for minting and burning of the flash minted amount.
-    function flashMint(uint112 value, bytes calldata data) external;
+    function flashMint(address receiver, uint256 value, bytes calldata data) external;
 
     /// @dev Burn `value` WETH10 token from caller account and withdraw matching ether to the same.
     /// Emits {Transfer} event to reflect WETH10 token burn of `value` WETH10 token to zero address from caller account. 

--- a/contracts/WETH10.sol
+++ b/contracts/WETH10.sol
@@ -11,8 +11,8 @@ interface ERC677Receiver {
 }
 
 // To be proposed as an ERC standard
-interface FlashMinterLike {
-    function onFlashMint(address user, uint256 value, uint256 fee, bytes calldata) external;
+interface flashLoanerLike {
+    function onflashLoan(address user, uint256 value, uint256 fee, bytes calldata) external;
 }
 
 interface WETH9Like {
@@ -95,17 +95,17 @@ contract WETH10 is IWETH10 {
     /// The flash minted WETH10 is not backed by real Ether, but can be withdrawn as such up to the Ether balance of this contract.
     /// Arbitrary data can be passed as a bytes calldata parameter.
     /// Emits two {Transfer} events for minting and burning of the flash minted amount.
-    function flashMint(address receiver, uint256 value, bytes calldata data) external override {
-        require(value <= type(uint112).max, "WETH::flashMint: flash mint limit exceeded");
+    function flashLoan(address receiver, uint256 value, bytes calldata data) external override {
+        require(value <= type(uint112).max, "WETH::flashLoan: flash mint limit exceeded");
         flashSupply += value;
-        require(address(this).balance + flashSupply <= type(uint112).max, "WETH::flashMint: supply limit exceeded");
+        require(address(this).balance + flashSupply <= type(uint112).max, "WETH::flashLoan: supply limit exceeded");
         balanceOf[receiver] += value;
         emit Transfer(address(0), receiver, value);
 
-        FlashMinterLike(receiver).onFlashMint(msg.sender, value, 0, data);
+        flashLoanerLike(receiver).onflashLoan(msg.sender, value, 0, data);
 
         uint256 balance = balanceOf[address(this)];
-        require(balance >= value, "WETH::flashMint: not enough balance to resolve");
+        require(balance >= value, "WETH::flashLoan: not enough balance to resolve");
         balanceOf[address(this)] = balance - value;
         flashSupply -= value;
         emit Transfer(address(this), address(0), value);

--- a/contracts/tests/TestFlashMinter.sol
+++ b/contracts/tests/TestFlashMinter.sol
@@ -2,15 +2,15 @@
 pragma solidity 0.7.0;
 
 
-interface FlashMintableLike {
-    function flashMint(address receiver, uint256 value, bytes calldata) external;
+interface flashLoanableLike {
+    function flashLoan(address receiver, uint256 value, bytes calldata) external;
     function balanceOf(address) external returns (uint256);
     function deposit() external payable;
     function withdraw(uint256) external;
     function transfer(address, uint256) external;
 }
 
-contract TestFlashMinter {
+contract TestflashLoaner {
     enum Action {NORMAL, STEAL, WITHDRAW, REENTER}
 
     uint256 public flashBalance;
@@ -19,47 +19,47 @@ contract TestFlashMinter {
 
     receive() external payable {}
 
-    function onFlashMint(address user, uint256 value, uint256, bytes calldata data) external {
+    function onflashLoan(address user, uint256 value, uint256, bytes calldata data) external {
         (Action action) = abi.decode(data, (Action)); // Use this to unpack arbitrary data
         flashUser = user;
         flashValue = value;
         if (action == Action.NORMAL) {
-            flashBalance = FlashMintableLike(msg.sender).balanceOf(address(this));
-            FlashMintableLike(msg.sender).transfer(msg.sender, value); // Resolve the flash mint
+            flashBalance = flashLoanableLike(msg.sender).balanceOf(address(this));
+            flashLoanableLike(msg.sender).transfer(msg.sender, value); // Resolve the flash mint
         } else if (action == Action.WITHDRAW) {
-            FlashMintableLike(msg.sender).withdraw(value);
+            flashLoanableLike(msg.sender).withdraw(value);
             flashBalance = address(this).balance;
-            FlashMintableLike(msg.sender).deposit{ value: value }();
-            FlashMintableLike(msg.sender).transfer(msg.sender, value);
+            flashLoanableLike(msg.sender).deposit{ value: value }();
+            flashLoanableLike(msg.sender).transfer(msg.sender, value);
         } else if (action == Action.STEAL) {
             // Do nothing
         } else if (action == Action.REENTER) {
-            flashMint(msg.sender, value * 2);
-            FlashMintableLike(msg.sender).transfer(msg.sender, value);
+            flashLoan(msg.sender, value * 2);
+            flashLoanableLike(msg.sender).transfer(msg.sender, value);
         }
     }
 
-    function flashMint(address mint, uint256 value) public {
-        // Use this to pack arbitrary data to `executeOnFlashMint`
+    function flashLoan(address mint, uint256 value) public {
+        // Use this to pack arbitrary data to `onFlashLoan`
         bytes memory data = abi.encode(Action.NORMAL);
-        FlashMintableLike(mint).flashMint(address(this), value, data);
+        flashLoanableLike(mint).flashLoan(address(this), value, data);
     }
 
-    function flashMintAndWithdraw(address mint, uint256 value) public {
-        // Use this to pack arbitrary data to `executeOnFlashMint`
+    function flashLoanAndWithdraw(address mint, uint256 value) public {
+        // Use this to pack arbitrary data to `onFlashLoan`
         bytes memory data = abi.encode(Action.WITHDRAW);
-        FlashMintableLike(mint).flashMint(address(this), value, data);
+        flashLoanableLike(mint).flashLoan(address(this), value, data);
     }
 
-    function flashMintAndSteal(address mint, uint256 value) public {
-        // Use this to pack arbitrary data to `executeOnFlashMint`
+    function flashLoanAndSteal(address mint, uint256 value) public {
+        // Use this to pack arbitrary data to `onFlashLoan`
         bytes memory data = abi.encode(Action.STEAL);
-        FlashMintableLike(mint).flashMint(address(this), value, data);
+        flashLoanableLike(mint).flashLoan(address(this), value, data);
     }
 
-    function flashMintAndReenter(address mint, uint256 value) public {
-        // Use this to pack arbitrary data to `executeOnFlashMint`
+    function flashLoanAndReenter(address mint, uint256 value) public {
+        // Use this to pack arbitrary data to `onFlashLoan`
         bytes memory data = abi.encode(Action.REENTER);
-        FlashMintableLike(mint).flashMint(address(this), value, data);
+        flashLoanableLike(mint).flashLoan(address(this), value, data);
     }
 }

--- a/contracts/tests/TestFlashMinter.sol
+++ b/contracts/tests/TestFlashMinter.sol
@@ -3,7 +3,7 @@ pragma solidity 0.7.0;
 
 
 interface FlashMintableLike {
-    function flashMint(uint112, bytes calldata) external;
+    function flashMint(address receiver, uint256 value, bytes calldata) external;
     function balanceOf(address) external returns (uint256);
     function deposit() external payable;
     function withdraw(uint256) external;
@@ -11,7 +11,7 @@ interface FlashMintableLike {
 }
 
 contract TestFlashMinter {
-    enum Action {NORMAL, STEAL, WITHDRAW, REENTER, OVERSPEND}
+    enum Action {NORMAL, STEAL, WITHDRAW, REENTER}
 
     uint256 public flashBalance;
     uint256 public flashValue;
@@ -19,51 +19,47 @@ contract TestFlashMinter {
 
     receive() external payable {}
 
-    function executeOnFlashMint(bytes calldata data) external {
-        (Action action, address user, uint112 value) = abi.decode(data, (Action, address, uint112)); // Use this to unpack arbitrary data
+    function onFlashMint(address user, uint256 value, uint256, bytes calldata data) external {
+        (Action action) = abi.decode(data, (Action)); // Use this to unpack arbitrary data
         flashUser = user;
         flashValue = value;
         if (action == Action.NORMAL) {
             flashBalance = FlashMintableLike(msg.sender).balanceOf(address(this));
+            FlashMintableLike(msg.sender).transfer(msg.sender, value); // Resolve the flash mint
         } else if (action == Action.WITHDRAW) {
             FlashMintableLike(msg.sender).withdraw(value);
             flashBalance = address(this).balance;
             FlashMintableLike(msg.sender).deposit{ value: value }();
+            FlashMintableLike(msg.sender).transfer(msg.sender, value);
         } else if (action == Action.STEAL) {
-            FlashMintableLike(msg.sender).transfer(address(1), value);
+            // Do nothing
         } else if (action == Action.REENTER) {
             flashMint(msg.sender, value * 2);
-        } else if (action == Action.OVERSPEND) {
-            FlashMintableLike(msg.sender).transfer(address(0), 1);
+            FlashMintableLike(msg.sender).transfer(msg.sender, value);
         }
     }
 
-    function flashMint(address target, uint112 value) public {
+    function flashMint(address mint, uint256 value) public {
         // Use this to pack arbitrary data to `executeOnFlashMint`
-        bytes memory data = abi.encode(Action.NORMAL, msg.sender, value); // Here msg.sender is the user, and target is the weth contract
-        FlashMintableLike(target).flashMint(value, data);
+        bytes memory data = abi.encode(Action.NORMAL);
+        FlashMintableLike(mint).flashMint(address(this), value, data);
     }
 
-    function flashMintAndWithdraw(address target, uint112 value) public {
+    function flashMintAndWithdraw(address mint, uint256 value) public {
         // Use this to pack arbitrary data to `executeOnFlashMint`
-        bytes memory data = abi.encode(Action.WITHDRAW, msg.sender, value); // Here msg.sender is the user, and target is the weth contract
-        FlashMintableLike(target).flashMint(value, data);
+        bytes memory data = abi.encode(Action.WITHDRAW);
+        FlashMintableLike(mint).flashMint(address(this), value, data);
     }
 
-    function flashMintAndSteal(address target, uint112 value) public {
+    function flashMintAndSteal(address mint, uint256 value) public {
         // Use this to pack arbitrary data to `executeOnFlashMint`
-        bytes memory data = abi.encode(Action.STEAL, msg.sender, value); // Here msg.sender is the user, and target is the weth contract
-        FlashMintableLike(target).flashMint(value, data);
+        bytes memory data = abi.encode(Action.STEAL);
+        FlashMintableLike(mint).flashMint(address(this), value, data);
     }
 
-    function flashMintAndReenter(address target, uint112 value) public {
+    function flashMintAndReenter(address mint, uint256 value) public {
         // Use this to pack arbitrary data to `executeOnFlashMint`
-        bytes memory data = abi.encode(Action.REENTER, msg.sender, value); // Here msg.sender is the user, and target is the weth contract
-        FlashMintableLike(target).flashMint(value, data);
-    }
-
-    function flashMintAndOverspend(address target, uint112 value) public {
-        bytes memory data = abi.encode(Action.OVERSPEND, msg.sender, value); // Here msg.sender is the user, and target is the weth contract
-        FlashMintableLike(target).flashMint(value, data);
+        bytes memory data = abi.encode(Action.REENTER);
+        FlashMintableLike(mint).flashMint(address(this), value, data);
     }
 }

--- a/test/01_WETH10.test.js
+++ b/test/01_WETH10.test.js
@@ -46,14 +46,6 @@ contract('WETH10', (accounts) => {
       balanceAfter.toString().should.equal(balanceBefore.add(new BN('1')).toString())
     })
 
-    it('should not depositTo to the contract address', async () => {
-      await expectRevert(weth10.depositTo(weth10.address, { value: 1, from: user1 }), 'WETH::depositTo: invalid recipient')
-    })
-
-    it('should not depositToAndCall to the contract address', async () => {
-      await expectRevert(weth10.depositToAndCall(weth10.address, '0x11', { from: user1, value: 1 }), 'WETH::depositToAndCall: invalid recipient')
-    })
-
     it('deposits with depositToAndCall', async () => {
       const receiver = await TestERC677Receiver.new()
       await weth10.depositToAndCall(receiver.address, '0x11', { from: user1, value: 1 })
@@ -97,11 +89,6 @@ contract('WETH10', (accounts) => {
         toBalanceAfter.toString().should.equal(toBalanceBefore.add(new BN('1')).toString())
       })
 
-      it('should not withdraw to the contract address', async () => {
-        await expectRevert(weth10.withdrawTo(weth10.address, 1, { from: user1 }), 'WETH::withdrawTo: invalid recipient')
-        await expectRevert(weth10.withdrawFrom(user1, weth10.address, 1, { from: user1 }), 'WETH::withdrawFrom: invalid recipient')
-      })
-
       it('should not withdraw beyond balance', async () => {
         await expectRevert(weth10.withdraw(100, { from: user1 }), 'WETH::withdraw: withdraw amount exceeds balance')
         await expectRevert(weth10.withdrawTo(user2, 100, { from: user1 }), 'WETH::withdrawTo: withdraw amount exceeds balance')
@@ -133,12 +120,6 @@ contract('WETH10', (accounts) => {
         events[0].returnValues.sender.should.equal(user1)
         events[0].returnValues.value.should.equal('1')
         events[0].returnValues.data.should.equal('0x11')
-      })
-
-      it('should not transfer to the contract address', async () => {
-        await expectRevert(weth10.transfer(weth10.address, 1, { from: user1 }), 'WETH::transfer: invalid recipient')
-        await expectRevert(weth10.transferFrom(user1, weth10.address, 1, { from: user1 }), 'WETH::transferFrom: invalid recipient')
-        await expectRevert(weth10.transferAndCall(weth10.address, 1, '0x11', { from: user1 }), 'WETH::transferAndCall: invalid recipient')
       })
 
       it('should not transfer beyond balance', async () => {

--- a/test/02_WETH10_Flash.test.js
+++ b/test/02_WETH10_Flash.test.js
@@ -29,6 +29,20 @@ contract('WETH10 - Flash Minting', (accounts) => {
     const flashValue = await flash.flashValue()
     flashValue.toString().should.equal(new BN('1').toString())
     const flashUser = await flash.flashUser()
+    flashUser.toString().should.equal(flash.address)
+  })
+
+
+  it('should do a simple flash mint from an EOA', async () => {
+    await weth10.flashMint(flash.address, 1, '0x0000000000000000000000000000000000000000000000000000000000000000', { from: user1 })
+
+    const balanceAfter = await weth10.balanceOf(user1)
+    balanceAfter.toString().should.equal(new BN('0').toString())
+    const flashBalance = await flash.flashBalance()
+    flashBalance.toString().should.equal(new BN('1').toString())
+    const flashValue = await flash.flashValue()
+    flashValue.toString().should.equal(new BN('1').toString())
+    const flashUser = await flash.flashUser()
     flashUser.toString().should.equal(user1)
   })
 
@@ -37,16 +51,9 @@ contract('WETH10 - Flash Minting', (accounts) => {
     await expectRevert(flash.flashMint(weth10.address, MAX, { from: user1 }), 'WETH::flashMint: supply limit exceeded')
   })
 
-  it('should not steal a flash mint', async () => {
-    await expectRevert(
-      flash.flashMintAndSteal(weth10.address, 1, { from: deployer }),
-      'WETH::flashMint: not enough balance to resolve'
-    )
-  })
-
   it('needs to return funds after a flash mint', async () => {
     await expectRevert(
-      flash.flashMintAndOverspend(weth10.address, 1, { from: user1 }),
+      flash.flashMintAndSteal(weth10.address, 1, { from: deployer }),
       'WETH::flashMint: not enough balance to resolve'
     )
   })


### PR DESCRIPTION
Aiming to define a standard interface for flash minting, this refactor uses the same interface [proposed for MakerDAO](https://github.com/hexonaut/dss-flash/issues/11).

The main difference is that now `flashMint` is called `flashLoan` and takes a `receiver` address which the tokens will be minted to. It is responsibility of the `receiver` to return the tokens to `WETH10`, where they would be burned.

Since now there is a valid reason to send WETH10 (or even Ether) to the WETH10 contract, the `require(to != address(this))` have been removed.

Incidentally, any WETH10 locked in the WETH10 contract can be retrieved by anyone using a flash mint.