### PR TITLE
test gas use with solc8

### DIFF
--- a/buidler.config.js
+++ b/buidler.config.js
@@ -65,7 +65,7 @@ module.exports = {
     },
   },
   solc: {
-    version: '0.7.6',
+    version: '0.8.0',
     optimizer: {
       enabled: true,
       runs: 20000,

--- a/contracts/WETH10.sol
+++ b/contracts/WETH10.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2015, 2016, 2017 Dapphub
 // Adapted by Ethereum Community 2020
-pragma solidity 0.7.6;
+pragma solidity ^0.8.0;
 
 import "./interfaces/IWETH10.sol";
 import "./interfaces/IERC3156FlashBorrower.sol";
@@ -109,7 +109,7 @@ contract WETH10 is IWETH10 {
     ///   - caller account must have at least `value` balance of WETH10 token.
     function withdraw(uint256 value) external override {
         _burnFrom(msg.sender, value);
-        _transferEther(msg.sender, value);
+        _transferEther(payable(msg.sender), value);
     }
 
     /// @dev Burn `value` WETH10 token from caller account and withdraw matching ether to account (`to`).
@@ -244,7 +244,7 @@ contract WETH10 is IWETH10 {
     function _decreaseAllowance(address owner, address spender, uint256 value) internal {
         uint256 allowed = allowance[owner][spender];
         if (allowed != type(uint256).max) {
-            require(allowed >= value, "WETH: request exceeds allowance");
+            // require(allowed >= value, "WETH: request exceeds allowance");
             _approve(owner, spender, allowed - value);
         }
     }
@@ -260,10 +260,10 @@ contract WETH10 is IWETH10 {
     /// - caller account must have at least `value` allowance from account (`from`).
     function _transferFrom(address from, address to, uint256 value) internal returns (bool) {
         if(to != address(0)) { // Transfer
-            uint256 balance = balanceOf[from];
-            require(balance >= value, "WETH: transfer amount exceeds balance");
+            // uint256 balance = balanceOf[from];
+            // require(balance >= value, "WETH: transfer amount exceeds balance");
 
-            balanceOf[from] = balance - value;
+            balanceOf[from] -= value;
             balanceOf[to] += value;
             emit Transfer(from, to, value);
         } else { // Withdraw
@@ -299,9 +299,9 @@ contract WETH10 is IWETH10 {
     /// - owner account (`from`) must have at least `value` WETH10 token.
     /// - caller account must have at least `value` allowance from account (`from`).
     function _burnFrom(address from, uint256 value) internal {
-        uint256 balance = balanceOf[from];
-        require(balance >= value, "WETH: burn amount exceeds balance");
-        balanceOf[from] = balance - value;
+        // uint256 balance = balanceOf[from];
+        // require(balance >= value, "WETH: burn amount exceeds balance");
+        balanceOf[from] -= value;
         emit Transfer(from, address(0), value);
     }
 }

--- a/contracts/WethConverter.sol
+++ b/contracts/WethConverter.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2015, 2016, 2017 Dapphub
 // Adapted by Ethereum Community 2020
-pragma solidity 0.7.6;
+pragma solidity ^0.8.0;
 
 
 interface WETH9Like {

--- a/contracts/fuzzing/WETH10Fuzzing.sol
+++ b/contracts/fuzzing/WETH10Fuzzing.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity ^0.7.6;
+pragma solidity ^0.8.0;
 import "../WETH10.sol";
 
 
@@ -19,7 +19,7 @@ contract WETH10Fuzzing {
     /// @dev Instantiate the WETH10 contract, and a holder address that will return weth when asked to.
     constructor () {
         weth = new WETH10();
-        holder = address(new MockHolder(address(weth), address(this)));
+        holder = address(new MockHolder(payable(weth), address(this)));
     }
 
     /// @dev Receive ETH when withdrawing.

--- a/contracts/interfaces/IERC20.sol
+++ b/contracts/interfaces/IERC20.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: MIT
 
-pragma solidity ^0.7.6;
+pragma solidity ^0.8.0;
 
 /**
  * @dev Interface of the ERC20 standard as defined in the EIP.

--- a/contracts/interfaces/IERC2612.sol
+++ b/contracts/interfaces/IERC2612.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Code adapted from https://github.com/OpenZeppelin/openzeppelin-contracts/pull/2237/
-pragma solidity ^0.7.6;
+pragma solidity ^0.8.0;
 
 /**
  * @dev Interface of the ERC2612 standard as defined in the EIP.

--- a/contracts/interfaces/IERC3156FlashBorrower.sol
+++ b/contracts/interfaces/IERC3156FlashBorrower.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.7.6;
+pragma solidity ^0.8.0;
 
 
 interface IERC3156FlashBorrower {

--- a/contracts/interfaces/IERC3156FlashLender.sol
+++ b/contracts/interfaces/IERC3156FlashLender.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.7.6;
+pragma solidity ^0.8.0;
 
 interface IERC3156FlashLender {
     function flashLoan(address receiver, address token, uint256 value, bytes calldata) external;

--- a/contracts/interfaces/IWETH10.sol
+++ b/contracts/interfaces/IWETH10.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2015, 2016, 2017 Dapphub
 // Adapted by Ethereum Community 2020
-pragma solidity 0.7.6;
+pragma solidity ^0.8.0;
 import "./IERC20.sol";
 import "./IERC2612.sol";
 import "./IERC3156FlashLender.sol";

--- a/contracts/tests/TestFlashMinter.sol
+++ b/contracts/tests/TestFlashMinter.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
-pragma solidity 0.7.6;
+pragma solidity ^0.8.0;
 
 import "../interfaces/IWETH10.sol";
 import "../interfaces/IERC3156FlashBorrower.sol";

--- a/contracts/tests/TestTransferReceiver.sol
+++ b/contracts/tests/TestTransferReceiver.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2015, 2016, 2017 Dapphub / adapted by [] 2020
-pragma solidity 0.7.6;
+pragma solidity ^0.8.0;
 
 
 contract TestTransferReceiver {

--- a/contracts/tests/WETH9.sol
+++ b/contracts/tests/WETH9.sol
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-pragma solidity ^0.7.6;
+pragma solidity ^0.8.0;
 
 contract WETH9 {
     string public name     = "Wrapped Ether";
@@ -39,7 +39,7 @@ contract WETH9 {
     function withdraw(uint wad) public {
         require(balanceOf[msg.sender] >= wad);
         balanceOf[msg.sender] -= wad;
-        msg.sender.transfer(wad);
+        payable(msg.sender).transfer(wad);
         emit Withdrawal(msg.sender, wad);
     }
 
@@ -63,7 +63,7 @@ contract WETH9 {
     {
         require(balanceOf[src] >= wad);
 
-        if (src != msg.sender && allowance[src][msg.sender] != uint(-1)) {
+        if (src != msg.sender && allowance[src][msg.sender] != type(uint).max) {
             require(allowance[src][msg.sender] >= wad);
             allowance[src][msg.sender] -= wad;
         }


### PR DESCRIPTION
Made a test of using the 0.8.0 compiler. Safer, but more expensive.

Function | solc 0.7.5 | solc 0.8.0 | Diff
-- | -- | -- | --
approve | 44029 | 44190 | 161
approveAndCall | 49295 | 49817 | 522
deposit | 44854 | 45043 | 189
depositTo | 45229 | 45510 | 281
depositToAndCall | 50712 | 51393 | 681
permit | 71749 | 72250 | 501
transfer | 56458 | 56657 | 199
transferAndCall | 56060 | 56653 | 593
transferFrom | 46291 | 46583 | 292
withdraw | 36855 | 36927 | 72
withdrawFrom | 34708 | 34936 | 228
withdrawTo | 37269 | 37404 | 135

