### PR TITLE
add DOMAIN_SEPARATOR public view function

### DIFF
--- a/contracts/WETH10.sol
+++ b/contracts/WETH10.sol
@@ -49,7 +49,9 @@ contract WETH10 is IWETH10 {
                 keccak256(bytes(name)),
                 keccak256(bytes("1")),
                 chainId,
-                address(this)));
+                address(this)
+            )
+        );
     }
     
     /// @dev Returns the total supply of WETH10 token as the ETH held in this contract.

--- a/contracts/WETH10.sol
+++ b/contracts/WETH10.sol
@@ -14,7 +14,7 @@ interface IApprovalReceiver {
     function onTokenApproval(address, uint, bytes calldata) external returns (bool);
 }
 
-/// @dev Wrapped Ether v10 (WETH10) is an Ether (ETH) ERC-20 wrapper. You can `deposit` ETH and obtain an WETH10 balance which can then be operated as an ERC-20 token. You can
+/// @dev Wrapped Ether v10 (WETH10) is an Ether (ETH) ERC-20 wrapper. You can `deposit` ETH and obtain a WETH10 balance which can then be operated as an ERC-20 token. You can
 /// `withdraw` ETH from WETH10, which will then burn WETH10 token in your wallet. The amount of WETH10 token in any wallet is always identical to the
 /// balance of ETH deposited minus the ETH withdrawn with that specific wallet.
 contract WETH10 is IWETH10 {
@@ -55,12 +55,12 @@ contract WETH10 is IWETH10 {
     }
     
     /// @dev Returns the total supply of WETH10 token as the ETH held in this contract.
-    function totalSupply() external view override returns(uint256) {
+    function totalSupply() external view override returns (uint256) {
         return address(this).balance + flashMinted;
     }
 
     /// @dev Fallback, `msg.value` of ETH sent to this contract grants caller account a matching increase in WETH10 token balance.
-    /// Emits {Transfer} event to reflect WETH10 token mint of `msg.value` from zero address to caller account.
+    /// Emits {Transfer} event to reflect WETH10 token mint of `msg.value` from `address(0)` to caller account.
     receive() external payable {
         // _mintTo(msg.sender, msg.value);
         balanceOf[msg.sender] += msg.value;
@@ -68,7 +68,7 @@ contract WETH10 is IWETH10 {
     }
 
     /// @dev `msg.value` of ETH sent to this contract grants caller account a matching increase in WETH10 token balance.
-    /// Emits {Transfer} event to reflect WETH10 token mint of `msg.value` from zero address to caller account.
+    /// Emits {Transfer} event to reflect WETH10 token mint of `msg.value` from `address(0)` to caller account.
     function deposit() external override payable {
         // _mintTo(msg.sender, msg.value);
         balanceOf[msg.sender] += msg.value;
@@ -76,7 +76,7 @@ contract WETH10 is IWETH10 {
     }
 
     /// @dev `msg.value` of ETH sent to this contract grants `to` account a matching increase in WETH10 token balance.
-    /// Emits {Transfer} event to reflect WETH10 token mint of `msg.value` from zero address to `to` account.
+    /// Emits {Transfer} event to reflect WETH10 token mint of `msg.value` from `address(0)` to `to` account.
     function depositTo(address to) external override payable {
         // _mintTo(to, msg.value);
         balanceOf[to] += msg.value;
@@ -87,7 +87,7 @@ contract WETH10 is IWETH10 {
     /// after which a call is executed to an ERC677-compliant contract with the `data` parameter.
     /// Emits {Transfer} event.
     /// Returns boolean value indicating whether operation succeeded.
-    /// For more information on *transferAndCall* format, see https://github.com/ethereum/EIPs/issues/677.
+    /// For more information on {transferAndCall} format, see https://github.com/ethereum/EIPs/issues/677.
     function depositToAndCall(address to, bytes calldata data) external override payable returns (bool success) {
         // _mintTo(to, msg.value);
         balanceOf[to] += msg.value;
@@ -101,7 +101,7 @@ contract WETH10 is IWETH10 {
         return token == address(this) ? type(uint112).max - flashMinted : 0; // Can't underflow
     }
 
-    /// @dev Return the fee (zero) for flash-lending an amount of WETH10 token.
+    /// @dev Return the fee (zero) for flash lending an amount of WETH10 token.
     function flashFee(address token, uint256) external view override returns (uint256) {
         require(token == address(this), "WETH: flash mint only WETH10");
         return 0;
@@ -118,7 +118,7 @@ contract WETH10 is IWETH10 {
     /// Requirements:
     ///   - `value` must be less or equal to type(uint112).max.
     ///   - The total of all flash loans in a tx must be less or equal to type(uint112).max.
-    function flashLoan(IERC3156FlashBorrower receiver, address token, uint256 value, bytes calldata data) external override returns(bool) {
+    function flashLoan(IERC3156FlashBorrower receiver, address token, uint256 value, bytes calldata data) external override returns (bool) {
         require(token == address(this), "WETH: flash mint only WETH10");
         require(value <= type(uint112).max, "WETH: individual loan limit exceeded");
         flashMinted = flashMinted + value;
@@ -153,7 +153,7 @@ contract WETH10 is IWETH10 {
     }
 
     /// @dev Burn `value` WETH10 token from caller account and withdraw matching ETH to the same.
-    /// Emits {Transfer} event to reflect WETH10 token burn of `value` to zero address from caller account. 
+    /// Emits {Transfer} event to reflect WETH10 token burn of `value` to `address(0)` from caller account. 
     /// Requirements:
     ///   - caller account must have at least `value` balance of WETH10 token.
     function withdraw(uint256 value) external override {
@@ -169,7 +169,7 @@ contract WETH10 is IWETH10 {
     }
 
     /// @dev Burn `value` WETH10 token from caller account and withdraw matching ETH to account (`to`).
-    /// Emits {Transfer} event to reflect WETH10 token burn of `value` to zero address from caller account.
+    /// Emits {Transfer} event to reflect WETH10 token burn of `value` to `address(0)` from caller account.
     /// Requirements:
     ///   - caller account must have at least `value` balance of WETH10 token.
     function withdrawTo(address payable to, uint256 value) external override {
@@ -187,7 +187,7 @@ contract WETH10 is IWETH10 {
     /// @dev Burn `value` WETH10 token from account (`from`) and withdraw matching ETH to account (`to`).
     /// Emits {Approval} event to reflect reduced allowance `value` for caller account to spend from account (`from`),
     /// unless allowance is set to `type(uint256).max`
-    /// Emits {Transfer} event to reflect WETH10 token burn of `value` to zero address from account (`from`).
+    /// Emits {Transfer} event to reflect WETH10 token burn of `value` to `address(0)` from account (`from`).
     /// Requirements:
     ///   - `from` account must have at least `value` balance of WETH10 token.
     ///   - `from` account must have approved caller to spend at least `value` of WETH10 token, unless `from` and caller are the same account.
@@ -229,7 +229,7 @@ contract WETH10 is IWETH10 {
     /// after which a call is executed to an ERC677-compliant contract with the `data` parameter.
     /// Emits {Approval} event.
     /// Returns boolean value indicating whether operation succeeded.
-    /// For more information on approveAndCall format, see https://github.com/ethereum/EIPs/issues/677.
+    /// For more information on {approveAndCall} format, see https://github.com/ethereum/EIPs/issues/677.
     function approveAndCall(address spender, uint256 value, bytes calldata data) external override returns (bool) {
         // _approve(msg.sender, spender, value);
         allowance[msg.sender][spender] = value;
@@ -244,7 +244,7 @@ contract WETH10 is IWETH10 {
     ///   - `deadline` must be timestamp in future.
     ///   - `v`, `r` and `s` must be valid `secp256k1` signature from `owner` account over EIP712-formatted function arguments.
     ///   - the signature must use `owner` account's current nonce (see {nonces}).
-    ///   - the signer cannot be zero address and must be `owner` account.
+    ///   - the signer cannot be `address(0)` and must be `owner` account.
     /// For more information on signature format, see https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP section].
     /// WETH10 token implementation adapted from https://github.com/albertocuestacanada/ERC20Permit/blob/master/contracts/ERC20Permit.sol.
     function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external override {
@@ -351,7 +351,7 @@ contract WETH10 is IWETH10 {
     /// Returns boolean value indicating whether operation succeeded.
     /// Requirements:
     ///   - caller account must have at least `value` WETH10 token.
-    /// For more information on transferAndCall format, see https://github.com/ethereum/EIPs/issues/677.
+    /// For more information on {transferAndCall} format, see https://github.com/ethereum/EIPs/issues/677.
     function transferAndCall(address to, uint value, bytes calldata data) external override returns (bool) {
         // _transferFrom(msg.sender, to, value);
         if (to != address(0)) { // Transfer

--- a/contracts/WETH10.sol
+++ b/contracts/WETH10.sol
@@ -25,6 +25,7 @@ contract WETH10 is IWETH10 {
 
     bytes32 public immutable CALLBACK_SUCCESS = keccak256("ERC3156FlashBorrower.onFlashLoan");
     bytes32 public immutable PERMIT_TYPEHASH = keccak256("Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)");
+    bytes32 public override immutable DOMAIN_SEPARATOR;
 
     /// @dev Records amount of WETH10 token owned by account.
     mapping (address => uint256) public override balanceOf;
@@ -38,6 +39,18 @@ contract WETH10 is IWETH10 {
 
     /// @dev Current amount of flash-minted WETH10 token.
     uint256 public override flashMinted;
+    
+    constructor() {
+        uint256 chainId;
+        assembly {chainId := chainid()}
+        DOMAIN_SEPARATOR = keccak256(
+            abi.encode(
+                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+                keccak256(bytes(name)),
+                keccak256(bytes("1")),
+                chainId,
+                address(this)));
+    }
     
     /// @dev Returns the total supply of WETH10 token as the ETH held in this contract.
     function totalSupply() external view override returns(uint256) {
@@ -234,16 +247,6 @@ contract WETH10 is IWETH10 {
     /// WETH10 token implementation adapted from https://github.com/albertocuestacanada/ERC20Permit/blob/master/contracts/ERC20Permit.sol.
     function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external override {
         require(block.timestamp <= deadline, "WETH: Expired permit");
-
-        uint256 chainId;
-        assembly {chainId := chainid()}
-        bytes32 DOMAIN_SEPARATOR = keccak256(
-            abi.encode(
-                keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
-                keccak256(bytes(name)),
-                keccak256(bytes("1")),
-                chainId,
-                address(this)));
 
         bytes32 hashStruct = keccak256(
             abi.encode(

--- a/contracts/WETH10.sol
+++ b/contracts/WETH10.sol
@@ -1,6 +1,6 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2015, 2016, 2017 Dapphub
-// Adapted by Ethereum Community 2020
+// Adapted by Ethereum Community 2021
 pragma solidity 0.7.6;
 
 import "./interfaces/IWETH10.sol";

--- a/contracts/interfaces/IERC2612.sol
+++ b/contracts/interfaces/IERC2612.sol
@@ -46,7 +46,7 @@ interface IERC2612 {
     function nonces(address owner) external view returns (uint256);
     
     /**
-     * @dev Returns the domain separator used in the encoding of the signature for `permit`, as defined by EIP712.
+     * @dev Returns the domain separator used in the encoding of the signature for {permit}, as defined by EIP712.
      */
     function DOMAIN_SEPARATOR() external view returns (bytes32);
 }

--- a/contracts/interfaces/IERC2612.sol
+++ b/contracts/interfaces/IERC2612.sol
@@ -13,7 +13,7 @@ pragma solidity ^0.7.6;
  */
 interface IERC2612 {
     /**
-     * @dev Sets `amount` as the allowance of `spender` over `owner`'s tokens,
+     * @dev Sets `value` as the allowance of `spender` over `owner`'s tokens,
      * given `owner`'s signed approval.
      *
      * IMPORTANT: The same issues {IERC20-approve} has related to transaction
@@ -28,19 +28,19 @@ interface IERC2612 {
      * - `deadline` must be a timestamp in the future.
      * - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`
      * over the EIP712-formatted function arguments.
-     * - the signature must use ``owner``'s current nonce (see {nonces}).
+     * - the signature must use `owner`'s current nonce (see {nonces}).
      *
      * For more information on the signature format, see the
      * https://eips.ethereum.org/EIPS/eip-2612#specification[relevant EIP
      * section].
      */
-    function permit(address owner, address spender, uint256 amount, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
+    function permit(address owner, address spender, uint256 value, uint256 deadline, uint8 v, bytes32 r, bytes32 s) external;
 
     /**
      * @dev Returns the current ERC2612 nonce for `owner`. This value must be
      * included whenever a signature is generated for {permit}.
      *
-     * Every successful call to {permit} increases ``owner``'s nonce by one. This
+     * Every successful call to {permit} increases `owner`'s nonce by one. This
      * prevents a signature from being used multiple times.
      */
     function nonces(address owner) external view returns (uint256);

--- a/contracts/interfaces/IERC2612.sol
+++ b/contracts/interfaces/IERC2612.sol
@@ -44,4 +44,9 @@ interface IERC2612 {
      * prevents a signature from being used multiple times.
      */
     function nonces(address owner) external view returns (uint256);
+    
+    /**
+     * @dev Returns the domain separator used in the encoding of the signature for `permit`, as defined by EIP712.
+     */
+    function DOMAIN_SEPARATOR() external view returns (bytes32);
 }

--- a/contracts/interfaces/IERC2612.sol
+++ b/contracts/interfaces/IERC2612.sol
@@ -23,8 +23,8 @@ interface IERC2612 {
      *
      * Requirements:
      *
-     * - `owner` cannot be the zero address.
-     * - `spender` cannot be the zero address.
+     * - `owner` cannot be `address(0)`.
+     * - `spender` cannot be `address(0)`.
      * - `deadline` must be a timestamp in the future.
      * - `v`, `r` and `s` must be a valid `secp256k1` signature from `owner`
      * over the EIP712-formatted function arguments.

--- a/contracts/interfaces/IWETH10.sol
+++ b/contracts/interfaces/IWETH10.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2015, 2016, 2017 Dapphub
-// Adapted by Ethereum Community 2020
+// Adapted by Ethereum Community 2021
 pragma solidity 0.7.6;
 
 import "./IERC20.sol";
 import "./IERC2612.sol";
 import "erc3156/contracts/interfaces/IERC3156FlashLender.sol";
 
-/// @dev Wrapped Ether v10 (WETH10) is an Ether (ETH) ERC-20 wrapper. You can `deposit` ETH and obtain an WETH10 balance which can then be operated as an ERC-20 token. You can
+/// @dev Wrapped Ether v10 (WETH10) is an Ether (ETH) ERC-20 wrapper. You can `deposit` ETH and obtain a WETH10 balance which can then be operated as an ERC-20 token. You can
 /// `withdraw` ETH from WETH10, which will then burn WETH10 token in your wallet. The amount of WETH10 token in any wallet is always identical to the
 /// balance of ETH deposited minus the ETH withdrawn with that specific wallet.
 interface IWETH10 is IERC20, IERC2612, IERC3156FlashLender {
@@ -16,21 +16,21 @@ interface IWETH10 is IERC20, IERC2612, IERC3156FlashLender {
     function flashMinted() external view returns(uint256);
 
     /// @dev `msg.value` of ETH sent to this contract grants caller account a matching increase in WETH10 token balance.
-    /// Emits {Transfer} event to reflect WETH10 token mint of `msg.value` from zero address to caller account.
+    /// Emits {Transfer} event to reflect WETH10 token mint of `msg.value` from `address(0)` to caller account.
     function deposit() external payable;
 
     /// @dev `msg.value` of ETH sent to this contract grants `to` account a matching increase in WETH10 token balance.
-    /// Emits {Transfer} event to reflect WETH10 token mint of `msg.value` from zero address to `to` account.
+    /// Emits {Transfer} event to reflect WETH10 token mint of `msg.value` from `address(0)` to `to` account.
     function depositTo(address to) external payable;
 
     /// @dev Burn `value` WETH10 token from caller account and withdraw matching ETH to the same.
-    /// Emits {Transfer} event to reflect WETH10 token burn of `value` to zero address from caller account. 
+    /// Emits {Transfer} event to reflect WETH10 token burn of `value` to `address(0)` from caller account. 
     /// Requirements:
     ///   - caller account must have at least `value` balance of WETH10 token.
     function withdraw(uint256 value) external;
 
     /// @dev Burn `value` WETH10 token from caller account and withdraw matching ETH to account (`to`).
-    /// Emits {Transfer} event to reflect WETH10 token burn of `value` to zero address from caller account.
+    /// Emits {Transfer} event to reflect WETH10 token burn of `value` to `address(0)` from caller account.
     /// Requirements:
     ///   - caller account must have at least `value` balance of WETH10 token.
     function withdrawTo(address payable to, uint256 value) external;
@@ -38,7 +38,7 @@ interface IWETH10 is IERC20, IERC2612, IERC3156FlashLender {
     /// @dev Burn `value` WETH10 token from account (`from`) and withdraw matching ETH to account (`to`).
     /// Emits {Approval} event to reflect reduced allowance `value` for caller account to spend from account (`from`),
     /// unless allowance is set to `type(uint256).max`
-    /// Emits {Transfer} event to reflect WETH10 token burn of `value` to zero address from account (`from`).
+    /// Emits {Transfer} event to reflect WETH10 token burn of `value` to `address(0)` from account (`from`).
     /// Requirements:
     ///   - `from` account must have at least `value` balance of WETH10 token.
     ///   - `from` account must have approved caller to spend at least `value` of WETH10 token, unless `from` and caller are the same account.
@@ -48,14 +48,14 @@ interface IWETH10 is IERC20, IERC2612, IERC3156FlashLender {
     /// after which a call is executed to an ERC677-compliant contract with the `data` parameter.
     /// Emits {Transfer} event.
     /// Returns boolean value indicating whether operation succeeded.
-    /// For more information on *transferAndCall* format, see https://github.com/ethereum/EIPs/issues/677.
+    /// For more information on {transferAndCall} format, see https://github.com/ethereum/EIPs/issues/677.
     function depositToAndCall(address to, bytes calldata data) external payable returns (bool);
 
     /// @dev Sets `value` as allowance of `spender` account over caller account's WETH10 token,
     /// after which a call is executed to an ERC677-compliant contract with the `data` parameter.
     /// Emits {Approval} event.
     /// Returns boolean value indicating whether operation succeeded.
-    /// For more information on approveAndCall format, see https://github.com/ethereum/EIPs/issues/677.
+    /// For more information on {approveAndCall} format, see https://github.com/ethereum/EIPs/issues/677.
     function approveAndCall(address spender, uint256 value, bytes calldata data) external returns (bool);
 
     /// @dev Moves `value` WETH10 token from caller's account to account (`to`), 
@@ -65,6 +65,6 @@ interface IWETH10 is IERC20, IERC2612, IERC3156FlashLender {
     /// Returns boolean value indicating whether operation succeeded.
     /// Requirements:
     ///   - caller account must have at least `value` WETH10 token.
-    /// For more information on transferAndCall format, see https://github.com/ethereum/EIPs/issues/677.
+    /// For more information on {transferAndCall} format, see https://github.com/ethereum/EIPs/issues/677.
     function transferAndCall(address to, uint value, bytes calldata data) external returns (bool);
 }

--- a/test/01_WETH10.test.js
+++ b/test/01_WETH10.test.js
@@ -1,4 +1,3 @@
-const WETH9 = artifacts.require('WETH9')
 const WETH10 = artifacts.require('WETH10')
 const { signERC2612Permit } = require('eth-permit')
 const TestTransferReceiver = artifacts.require('TestTransferReceiver')
@@ -11,12 +10,10 @@ const MAX = "1157920892373161954235709850086879078532699846656405640394575840079
 
 contract('WETH10', (accounts) => {
   const [deployer, user1, user2, user3] = accounts
-  let weth9
   let weth10
 
   beforeEach(async () => {
-    weth9 = await WETH9.new({ from: deployer })
-    weth10 = await WETH10.new(weth9.address, { from: deployer })
+    weth10 = await WETH10.new({ from: deployer })
   })
 
   describe('deployment', async () => {

--- a/test/02_WETH10_Flash.test.js
+++ b/test/02_WETH10_Flash.test.js
@@ -1,4 +1,3 @@
-const WETH9 = artifacts.require('WETH9')
 const WETH10 = artifacts.require('WETH10')
 const TestFlashLender = artifacts.require('TestFlashLender')
 
@@ -9,13 +8,11 @@ const MAX = "5192296858534827628530496329220095"
 
 contract('WETH10 - Flash Minting', (accounts) => {
   const [deployer, user1, user2] = accounts
-  let weth9
   let weth10
   let flash
 
   beforeEach(async () => {
-    weth9 = await WETH9.new({ from: deployer })
-    weth10 = await WETH10.new(weth9.address, { from: deployer })
+    weth10 = await WETH10.new({ from: deployer })
     flash = await TestFlashLender.new({ from: deployer })
   })
 


### PR DESCRIPTION
this PR makes DOMAIN_SEPARATOR a public view function per EIP-2612 by:
- moving this variable from the `permit()` function into a new `constructor()`
- adding `DOMAIN_SEPARATOR()` into `IERC2612`.sol
- adding `DOMAIN_SEPARATOR()` into `WETH10` .sol as:

`bytes32 public override immutable DOMAIN_SEPARATOR;`

this PR addresses this issue: https://github.com/WETH10/WETH10/issues/89

further, syntax and other formatting details have been reviewed and conformed to aide clarity.