### PR TITLE
add hardcodes to WethConverter

### DIFF
--- a/contracts/WethConverter.sol
+++ b/contracts/WethConverter.sol
@@ -1,11 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // Copyright (C) 2015, 2016, 2017 Dapphub
-// Adapted by Ethereum Community 2020
+// Adapted by Ethereum Community 2021
 pragma solidity 0.7.6;
 
-
 interface WETH9Like {
-    function withdraw(uint) external payable;
+    function withdraw(uint) external;
     function deposit() external payable;
     function transfer(address, uint) external returns (bool);
     function transferFrom(address, address, uint) external returns (bool);
@@ -13,24 +12,25 @@ interface WETH9Like {
 
 interface WETH10Like {
     function depositTo(address) external payable;
-    function withdrawFrom(address, address, uint256) external payable;
+    function withdrawFrom(address, address, uint256) external;
 }
 
 contract WethConverter {
+    WETH9Like constant private weth9 = WETH9Like(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2); // ETH wrapper contract v9
+    WETH10Like constant private weth10 = WETH10Like(0xf4BB2e28688e89fCcE3c0580D37d36A7672E8A9F); // ETH wrapper contract v10
+    
+    receive() external payable {}
 
-    receive() external payable {
-    }
-
-    function weth9ToWeth10(WETH9Like weth9, WETH10Like weth10, address account, uint256 value) public {
+    function weth9ToWeth10(address account, uint256 value) external payable {
         weth9.transferFrom(account, address(this), value);
         weth9.withdraw(value);
-        weth10.depositTo{ value: value }(account);
+        weth10.depositTo{value: value + msg.value}(account);
     }
 
-    function weth10ToWeth9(WETH9Like weth9, WETH10Like weth10, address account, uint256 value) public {
+    function weth10ToWeth9(address account, uint256 value) external payable {
         weth10.withdrawFrom(account, address(this), value);
-        weth9.deposit{ value: value }();
-        weth9.transfer(account, value);
+        uint256 combined = value + msg.value;
+        weth9.deposit{value: combined}();
+        weth9.transfer(account, combined);
     }
 }
-


### PR DESCRIPTION
- update interfaces to match underlying tokens (removing 'payable' in some instances)
- hardcode weth9 and weth10 addresses rather than use params
- make converter functions 'payable' so user can wrap ETH as well in conversion
- minor spacing, formatting changes

deployment: [0x7b706466Ee101D6BEBBBc2c279c9D8c628b4cb25](0x7b706466Ee101D6BEBBBc2c279c9D8c628b4cb25)

questions:
- can this be optimized further before UI integration?
- should we add `permit()` to a new, separate `weth10ToWeth9withPermit()`?