### PR TITLE
fix: sending WETH to the contract becomes a withdraw

### DIFF
--- a/contracts/WETH8.sol
+++ b/contracts/WETH8.sol
@@ -298,7 +298,7 @@ contract WETH8 is IWETH8 {
     ///   - caller account must have at least `value` WETH8 token.
     function transfer(address to, uint256 value) external override returns (bool) {
         // _transferFrom(msg.sender, to, value);
-        if (to != address(0)) { // Transfer
+        if (to != address(this)) { // Transfer
             uint256 balance = balanceOf[msg.sender];
             require(balance >= value, "WETH: transfer amount exceeds balance");
 
@@ -341,7 +341,7 @@ contract WETH8 is IWETH8 {
         }
         
         // _transferFrom(from, to, value);
-        if (to != address(0)) { // Transfer
+        if (to != address(this)) { // Transfer
             uint256 balance = balanceOf[from];
             require(balance >= value, "WETH: transfer amount exceeds balance");
 

--- a/test/01_WETH8.test.js
+++ b/test/01_WETH8.test.js
@@ -99,9 +99,9 @@ contract('WETH8', (accounts) => {
         balanceAfter.toString().should.equal(balanceBefore.add(new BN('1')).toString())
       })
 
-      it('withdraws ether by transferring to address(0)', async () => {
+      it('withdraws ether by transferring to contract', async () => {
         const balanceBefore = await weth8.balanceOf(user1)
-        await weth8.transfer('0x0000000000000000000000000000000000000000', 1, { from: user1 })
+        await weth8.transfer(weth8.address, 1, { from: user1 })
         const balanceAfter = await weth8.balanceOf(user1)
         balanceAfter.toString().should.equal(balanceBefore.sub(new BN('1')).toString())
       })
@@ -113,9 +113,9 @@ contract('WETH8', (accounts) => {
         balanceAfter.toString().should.equal(balanceBefore.add(new BN('1')).toString())
       })
 
-      it('withdraws ether by transferring from someone to address(0)', async () => {
+      it('withdraws ether by transferring from someone to contract', async () => {
         const balanceBefore = await weth8.balanceOf(user1)
-        await weth8.transferFrom(user1, '0x0000000000000000000000000000000000000000', 1, { from: user1 })
+        await weth8.transferFrom(user1, weth8.address, 1, { from: user1 })
         const balanceAfter = await weth8.balanceOf(user1)
         balanceAfter.toString().should.equal(balanceBefore.sub(new BN('1')).toString())
       })


### PR DESCRIPTION
We had it that sending to 0 was a withdraw, which was counter-intuitive as shown by $GWEI